### PR TITLE
Enabled the editing and preview of Images in  edit post

### DIFF
--- a/components/opportunity/images/ImageDropzone.tsx
+++ b/components/opportunity/images/ImageDropzone.tsx
@@ -143,6 +143,15 @@ export function SelectedImages({
   );
 }
 
+// Get bucket ID with validation
+const getBucketId = () => {
+  const bucketId = process.env.NEXT_PUBLIC_APPWRITE_OPPORTUNITIES_BUCKET_ID;
+  if (!bucketId) {
+    throw new Error("NEXT_PUBLIC_APPWRITE_OPPORTUNITIES_BUCKET_ID is not configured");
+  }
+  return bucketId;
+};
+
 /**
  * ExistingImages:
  * Renders existing image thumbnails (from Appwrite storage) with remove buttons.
@@ -153,14 +162,12 @@ export function ExistingImages({
 }: ExistingImagesProps) {
   const [previewImageId, setPreviewImageId] = useState<string | null>(null);
   const opportunityStorage = createOpportunityStorage();
+  const bucketId = getBucketId();
 
   if (existingImages.length === 0) return null;
 
   const getImageUrl = (imageId: string) =>
-    opportunityStorage.getFileView(
-      process.env.NEXT_PUBLIC_APPWRITE_OPPORTUNITIES_BUCKET_ID,
-      imageId
-    );
+    opportunityStorage.getFileView(bucketId, imageId);
 
   return (
     <>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remove and preview existing images when editing opportunities.
  * Existing and newly uploaded images shown together with unified controls and count-aware limits.
  * Removed images are deleted after a successful update; newly uploaded images are merged with remaining existing images.

* **Improvements**
  * Image picker UI and disable/limit logic now account for existing images.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->