### PR TITLE
fix: set first toolkit content item automatically

### DIFF
--- a/app/toolkit/[id]/content/page.tsx
+++ b/app/toolkit/[id]/content/page.tsx
@@ -103,19 +103,13 @@ export default function ToolkitContentPage() {
       : 0;
 
   const didRedirectRef = useRef(false);
-  const contentLengthRef = useRef(contentItems.length);
 
   useEffect(() => {
-    if (
-      contentItems.length > 0 &&
-      !currentItem &&
-      contentItems.length !== contentLengthRef.current
-    ) {
+    if (contentItems.length > 0 && !currentItem) {
       const sortedItems = [...contentItems].sort(
         (a, b) => a.orderIndex - b.orderIndex
       );
       setCurrentItem(sortedItems[0]);
-      contentLengthRef.current = contentItems.length;
     }
   }, [contentItems, currentItem]);
 


### PR DESCRIPTION
## Summary
- Fix toolkit content not showing by default after purchase
- Remove unnecessary contentLengthRef and condition that prevented initial item selection
- The first content item is now automatically selected when content exists

Closes: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified initialization logic for toolkit content item selection

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->