### PR TITLE
Add description support in Google Calendar event

### DIFF
--- a/app/deadlines/page.tsx
+++ b/app/deadlines/page.tsx
@@ -16,19 +16,28 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 
 
-function handleAddToCalendar(title: string, endDate: string) {
+function handleAddToCalendar(title: string, endDate: string, description?: string) {
   const date = new Date(endDate);
 
   const year = date.getUTCFullYear();
   const month = String(date.getUTCMonth() + 1).padStart(2, "0");
   const day = String(date.getUTCDate()).padStart(2, "0");
 
-  
   const allDayDate = `${year}${month}${day}`;
+
+  // Add description to the URL if it exists
+  const descriptionParam = description 
+    ? `&details=${encodeURIComponent(description)}`
+    : '';
+
+  // Add reminders:
+  // - Email: 1 day before (1440 minutes)
+  // - Popup: 1 day before (1440 minutes), 6 hours before (360 minutes), 1 hour before (60 minutes)
+  const reminders = '&remind=email:1440&remind=popup:1440&remind=popup:360&remind=popup:60';
 
   const url = `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(
     title
-  )}&dates=${allDayDate}/${allDayDate}`;
+  )}&dates=${allDayDate}/${allDayDate}${descriptionParam}${reminders}`;
 
   window.open(url, "_blank", "noopener,noreferrer");
 }
@@ -208,7 +217,7 @@ export default function BookmarksPage() {
                 {item.endDate && (
                   <button
                     title="Add to calendar"
-                    onClick={() => handleAddToCalendar(item.title, item.endDate!)}
+                    onClick={() => handleAddToCalendar(item.title, item.endDate!, item.description)}
                     className="flex-shrink-0 text-gray-600 hover:text-gray-900 transition-colors"
                     aria-label="Add to calendar"
                   >


### PR DESCRIPTION
Event description now appears inside Google Calendar event details.
User gets notify 1 day before via email and 1 day, 6hrs, 1hr before the deadline via google cal notification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event descriptions are now included when adding deadlines to Google Calendar, providing more context in your calendar.
  * Automatic reminders are configured for calendar events, including email notifications and popup alerts at multiple intervals to ensure you don't miss important deadlines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->