### PR TITLE
feat: add one-click Google Calendar integration in tracker

### DIFF
--- a/app/api/tracker/calendar/route.ts
+++ b/app/api/tracker/calendar/route.ts
@@ -1,0 +1,418 @@
+import { auth } from "@/lib/auth";
+import { getSessionCached } from "@/lib/auth-session-cache";
+import { db } from "@/lib/db";
+import { account, trackerItems, user } from "@/lib/schema";
+import { and, eq } from "drizzle-orm";
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+const createCalendarEventSchema = z.object({
+  oppId: z.string().min(1),
+  title: z.string().min(1),
+  company: z.string().min(1),
+  deadline: z.string().min(1),
+  kind: z.enum(["internship", "opportunity"]).default("internship"),
+});
+
+const calendarReminderSettingsSchema = z.object({
+  weekBefore: z.boolean(),
+  dayBefore: z.boolean(),
+  hourBefore: z.boolean(),
+});
+
+interface GoogleCalendarEventSearchResponse {
+  items?: Array<{ id?: string }>;
+}
+
+interface GoogleCalendarErrorResponse {
+  error?: {
+    message?: string;
+  };
+}
+
+interface CalendarReminderSettings {
+  weekBefore: boolean;
+  dayBefore: boolean;
+  hourBefore: boolean;
+}
+
+interface GoogleCalendarConnectionState {
+  hasGoogleAccount: boolean;
+  hasCalendarScope: boolean;
+}
+
+const GOOGLE_CALENDAR_SCOPES = new Set([
+  "https://www.googleapis.com/auth/calendar",
+  "https://www.googleapis.com/auth/calendar.events",
+  "https://www.googleapis.com/auth/calendar.events.owned",
+  "https://www.googleapis.com/auth/calendar.app.created",
+]);
+
+function parseDeadlineDate(deadline: string) {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(deadline)) {
+    return deadline;
+  }
+
+  const parsed = new Date(deadline);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return parsed.toISOString().slice(0, 10);
+}
+
+function getNextDate(dateText: string) {
+  const current = new Date(`${dateText}T00:00:00.000Z`);
+  current.setUTCDate(current.getUTCDate() + 1);
+  return current.toISOString().slice(0, 10);
+}
+
+async function getUserReminderSettings(
+  userId: string
+): Promise<CalendarReminderSettings> {
+  if (!db) {
+    return {
+      weekBefore: true,
+      dayBefore: true,
+      hourBefore: true,
+    };
+  }
+
+  const [row] = await db
+    .select({
+      calendarReminderWeek: user.calendarReminderWeek,
+      calendarReminderDay: user.calendarReminderDay,
+      calendarReminderHour: user.calendarReminderHour,
+    })
+    .from(user)
+    .where(eq(user.id, userId))
+    .limit(1);
+
+  return {
+    weekBefore: row?.calendarReminderWeek ?? true,
+    dayBefore: row?.calendarReminderDay ?? true,
+    hourBefore: row?.calendarReminderHour ?? true,
+  };
+}
+
+async function getGoogleAccessToken(requestHeaders: Headers) {
+  try {
+    const tokenResponse = await auth.api.getAccessToken({
+      body: {
+        providerId: "google",
+      },
+      headers: requestHeaders,
+    });
+
+    return tokenResponse?.accessToken || null;
+  } catch {
+    return null;
+  }
+}
+
+function hasAnyCalendarScope(scopeValue: string | null | undefined) {
+  if (!scopeValue) {
+    return false;
+  }
+
+  const normalizedScopes = scopeValue
+    .split(/[\s,]+/)
+    .map((scope) => scope.trim())
+    .filter(Boolean);
+
+  return normalizedScopes.some((scope) => GOOGLE_CALENDAR_SCOPES.has(scope));
+}
+
+async function getGoogleCalendarConnectionState(
+  userId: string
+): Promise<GoogleCalendarConnectionState> {
+  if (!db) {
+    return {
+      hasGoogleAccount: false,
+      hasCalendarScope: false,
+    };
+  }
+
+  const googleAccounts = await db
+    .select({ scope: account.scope })
+    .from(account)
+    .where(and(eq(account.userId, userId), eq(account.providerId, "google")));
+
+  if (googleAccounts.length === 0) {
+    return {
+      hasGoogleAccount: false,
+      hasCalendarScope: false,
+    };
+  }
+
+  return {
+    hasGoogleAccount: true,
+    hasCalendarScope: googleAccounts.some((item) =>
+      hasAnyCalendarScope(item.scope)
+    ),
+  };
+}
+
+export async function GET() {
+  try {
+    const requestHeaders = await headers();
+    const session = await getSessionCached(requestHeaders);
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const [connectionState, reminders] = await Promise.all([
+      getGoogleCalendarConnectionState(session.user.id),
+      getUserReminderSettings(session.user.id),
+    ]);
+
+    return NextResponse.json({
+      connected: connectionState.hasCalendarScope,
+      reminders,
+    });
+  } catch (error) {
+    console.error("Error loading calendar config:", error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(req: Request) {
+  try {
+    if (!db) {
+      return NextResponse.json(
+        { error: "Database unavailable" },
+        { status: 500 }
+      );
+    }
+
+    const requestHeaders = await headers();
+    const session = await getSessionCached(requestHeaders);
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const parsed = calendarReminderSettingsSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+    }
+
+    await db
+      .update(user)
+      .set({
+        calendarReminderWeek: parsed.data.weekBefore,
+        calendarReminderDay: parsed.data.dayBefore,
+        calendarReminderHour: parsed.data.hourBefore,
+        updatedAt: new Date(),
+      })
+      .where(eq(user.id, session.user.id));
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error updating calendar config:", error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const requestHeaders = await headers();
+    const session = await getSessionCached(requestHeaders);
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const parsedBody = createCalendarEventSchema.safeParse(body);
+
+    if (!parsedBody.success) {
+      return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+    }
+
+    const parsedDeadline = parseDeadlineDate(parsedBody.data.deadline);
+    if (!parsedDeadline) {
+      return NextResponse.json({ error: "Invalid deadline" }, { status: 400 });
+    }
+
+    const [connectionState, accessToken, reminderSettings] = await Promise.all([
+      getGoogleCalendarConnectionState(session.user.id),
+      getGoogleAccessToken(requestHeaders),
+      getUserReminderSettings(session.user.id),
+    ]);
+
+    if (!connectionState.hasGoogleAccount) {
+      return NextResponse.json(
+        {
+          error: "Google Calendar is not connected",
+          code: "GOOGLE_CALENDAR_NOT_CONNECTED",
+        },
+        { status: 403 }
+      );
+    }
+
+    if (!connectionState.hasCalendarScope) {
+      return NextResponse.json(
+        {
+          error:
+            "Google Calendar scope is missing. Please connect Google Calendar from tracker.",
+          code: "GOOGLE_CALENDAR_SCOPE_MISSING",
+        },
+        { status: 403 }
+      );
+    }
+
+    if (!accessToken) {
+      return NextResponse.json(
+        {
+          error: "Google Calendar is not connected",
+          code: "GOOGLE_CALENDAR_NOT_CONNECTED",
+        },
+        { status: 403 }
+      );
+    }
+
+    const trackerKey = `${session.user.id}:${parsedBody.data.oppId}:${parsedDeadline}`;
+    const trackerItemWhere = and(
+      eq(trackerItems.userId, session.user.id),
+      eq(trackerItems.oppId, parsedBody.data.oppId)
+    );
+
+    const duplicateSearchUrl = new URL(
+      "https://www.googleapis.com/calendar/v3/calendars/primary/events"
+    );
+    duplicateSearchUrl.searchParams.set(
+      "privateExtendedProperty",
+      `ftbTrackerKey=${trackerKey}`
+    );
+    duplicateSearchUrl.searchParams.set("maxResults", "1");
+    duplicateSearchUrl.searchParams.set("singleEvents", "true");
+
+    const duplicateCheckResponse = await fetch(duplicateSearchUrl.toString(), {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (duplicateCheckResponse.ok) {
+      const existingEventData =
+        (await duplicateCheckResponse.json()) as GoogleCalendarEventSearchResponse;
+      if ((existingEventData.items || []).length > 0) {
+        const existingEventId = existingEventData.items?.[0]?.id;
+        if (db && existingEventId) {
+          await db
+            .update(trackerItems)
+            .set({
+              calendarEventId: existingEventId,
+              calendarEventSyncedAt: new Date(),
+              updatedAt: new Date(),
+            })
+            .where(trackerItemWhere);
+        }
+        return NextResponse.json({ success: true, alreadyExists: true });
+      }
+    }
+
+    const eventPayload = {
+      summary: `FTB Deadline: ${parsedBody.data.title}`,
+      description: `Company: ${parsedBody.data.company}\nType: ${parsedBody.data.kind}\nAdded from FTB tracker.`,
+      start: {
+        date: parsedDeadline,
+      },
+      end: {
+        date: getNextDate(parsedDeadline),
+      },
+      extendedProperties: {
+        private: {
+          ftbTrackerKey: trackerKey,
+        },
+      },
+      reminders: {
+        useDefault: false,
+        overrides: [
+          ...(reminderSettings.weekBefore
+            ? [{ method: "popup", minutes: 60 * 24 * 7 }]
+            : []),
+          ...(reminderSettings.dayBefore
+            ? [{ method: "popup", minutes: 60 * 24 }]
+            : []),
+          ...(reminderSettings.hourBefore
+            ? [{ method: "popup", minutes: 60 }]
+            : []),
+        ],
+      },
+    };
+
+    const createResponse = await fetch(
+      "https://www.googleapis.com/calendar/v3/calendars/primary/events",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(eventPayload),
+      }
+    );
+
+    if (!createResponse.ok) {
+      const errorBody = (await createResponse
+        .json()
+        .catch(() => ({}))) as GoogleCalendarErrorResponse;
+
+      if (createResponse.status === 403) {
+        return NextResponse.json(
+          {
+            error:
+              errorBody?.error?.message ||
+              "Google Calendar scope is missing. Please reconnect Google Calendar.",
+            code: "GOOGLE_CALENDAR_SCOPE_MISSING",
+          },
+          { status: 403 }
+        );
+      }
+
+      return NextResponse.json(
+        {
+          error:
+            errorBody?.error?.message ||
+            "Failed to create Google Calendar event",
+        },
+        { status: 502 }
+      );
+    }
+
+    const createdEvent = await createResponse.json();
+    if (db && createdEvent?.id) {
+      await db
+        .update(trackerItems)
+        .set({
+          calendarEventId: createdEvent.id,
+          calendarEventSyncedAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(trackerItemWhere);
+    }
+
+    return NextResponse.json({
+      success: true,
+      eventId: createdEvent?.id,
+      eventLink: createdEvent?.htmlLink,
+    });
+  } catch (error) {
+    console.error("Error creating Google Calendar event:", error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
+}

--- a/components/providers/TrackerProvider.tsx
+++ b/components/providers/TrackerProvider.tsx
@@ -1,445 +1,539 @@
 "use client";
 
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
-import { toast } from 'sonner';
-import { fetchInternshipsPaginated } from '@/lib/queries-internships';
-import { fetchOpportunitiesPaginated } from '@/lib/queries-opportunities';
-import { Internship, Opportunity } from '@/types/interfaces';
-import { createOpportunityStorage } from '@/lib/appwrite';
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  ReactNode,
+} from "react";
+import { toast } from "sonner";
+import { fetchInternshipsPaginated } from "@/lib/queries-internships";
+import { fetchOpportunitiesPaginated } from "@/lib/queries-opportunities";
+import { Internship, Opportunity } from "@/types/interfaces";
+import { createOpportunityStorage } from "@/lib/appwrite";
 
 export interface TrackerItem {
-    oppId: number | string;
-    status: string; // 'Not Applied' | 'Draft' | 'Applied' | 'Result Awaited' | 'Selected' | 'Rejected'
-    kind?: 'internship' | 'opportunity'; // Default to 'internship' if undefined
-    addedAt: string;
-    appliedAt: string | null;
-    result: string | null;
-    notes: string;
-    updatedAt?: string;
-    draftData?: unknown;
-    // Merged fields from API
-    title?: string;
-    company?: string;
-    location?: string;
-    type?: string;
-    deadline?: string;
-    logo?: string;
-    fit?: string;
-    fitColor?: string;
-    fitLabel?: string;
-    matchReason?: string;
-    expectedResultWindow?: string;
-    description?: string;
-    expectations?: string[];
-    eligibility?: string[];
-    skills?: string[];
-    tags?: string[];
-    [key: string]: unknown;
+  oppId: number | string;
+  status: string; // 'Not Applied' | 'Draft' | 'Applied' | 'Result Awaited' | 'Selected' | 'Rejected'
+  kind?: "internship" | "opportunity"; // Default to 'internship' if undefined
+  addedAt: string;
+  appliedAt: string | null;
+  result: string | null;
+  notes: string;
+  updatedAt?: string;
+  draftData?: unknown;
+  calendarEventId?: string | null;
+  calendarEventSyncedAt?: string | null;
+  // Merged fields from API
+  title?: string;
+  company?: string;
+  location?: string;
+  type?: string;
+  deadline?: string;
+  logo?: string;
+  fit?: string;
+  fitColor?: string;
+  fitLabel?: string;
+  matchReason?: string;
+  expectedResultWindow?: string;
+  description?: string;
+  expectations?: string[];
+  eligibility?: string[];
+  skills?: string[];
+  tags?: string[];
+  [key: string]: unknown;
 }
 
-export interface ManualTrackerInput extends Omit<Partial<TrackerItem>, 'oppId'> {
-    id?: number | string;
-    kind?: 'internship' | 'opportunity';
-    draftData?: unknown;
+export interface ManualTrackerInput
+  extends Omit<Partial<TrackerItem>, "oppId"> {
+  id?: number | string;
+  kind?: "internship" | "opportunity";
+  draftData?: unknown;
 }
 
 export interface TrackerEvent {
-    id: string; // Changed to string (UUID)
-    title: string;
-    date: string;
-    type: string;
-    description: string;
+  id: string; // Changed to string (UUID)
+  title: string;
+  date: string;
+  type: string;
+  description: string;
 }
 
 interface TrackerContextType {
-    items: TrackerItem[];
-    events: TrackerEvent[];
-    addToTracker: (oppOrId: number | string | ManualTrackerInput, initialStatus?: string, kind?: 'internship' | 'opportunity') => void;
-    removeFromTracker: (oppId: number | string) => void;
-    updateStatus: (oppId: number | string, status: string, extraData?: Record<string, unknown>) => void;
-    getStatus: (oppId: number | string) => string | null;
-    addEvent: (event: Omit<TrackerEvent, 'id'>) => void;
-    removeEvent: (id: string) => void; // Changed to string
-    isLoading: boolean;
+  items: TrackerItem[];
+  events: TrackerEvent[];
+  addToTracker: (
+    oppOrId: number | string | ManualTrackerInput,
+    initialStatus?: string,
+    kind?: "internship" | "opportunity"
+  ) => void;
+  removeFromTracker: (oppId: number | string) => void;
+  updateStatus: (
+    oppId: number | string,
+    status: string,
+    extraData?: Record<string, unknown>
+  ) => void;
+  getStatus: (oppId: number | string) => string | null;
+  addEvent: (event: Omit<TrackerEvent, "id">) => void;
+  removeEvent: (id: string) => void; // Changed to string
+  isLoading: boolean;
 }
 
 const TrackerContext = createContext<TrackerContextType | undefined>(undefined);
 
 export const useTracker = () => {
-    const context = useContext(TrackerContext);
-    if (!context) {
-        throw new Error('useTracker must be used within a TrackerProvider');
-    }
-    return context;
+  const context = useContext(TrackerContext);
+  if (!context) {
+    throw new Error("useTracker must be used within a TrackerProvider");
+  }
+  return context;
 };
 
 export const TrackerProvider = ({ children }: { children: ReactNode }) => {
-    const [trackedItems, setTrackedItems] = useState<TrackerItem[]>([]);
-    const [events, setEvents] = useState<TrackerEvent[]>([]);
-    const [hydratedItems, setHydratedItems] = useState<TrackerItem[]>([]);
-    const [isLoaded, setIsLoaded] = useState(false);
-    const [isFetching, setIsFetching] = useState(false);
+  const [trackedItems, setTrackedItems] = useState<TrackerItem[]>([]);
+  const [events, setEvents] = useState<TrackerEvent[]>([]);
+  const [hydratedItems, setHydratedItems] = useState<TrackerItem[]>([]);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [isFetching, setIsFetching] = useState(false);
 
-    // Initial Load from API with LocalStorage Fallback/Sync
-    useEffect(() => {
-        const initializeTracker = async () => {
+  // Initial Load from API with LocalStorage Fallback/Sync
+  useEffect(() => {
+    const initializeTracker = async () => {
+      try {
+        // 1. Fetch from API
+        const response = await fetch("/api/tracker");
+
+        if (response.ok) {
+          const data = await response.json();
+
+          // 2. Check if API has data
+          if (data.items && data.items.length > 0) {
+            setTrackedItems(data.items);
+            setEvents(data.events || []);
+            setIsLoaded(true);
+            return; // API is source of truth
+          }
+        }
+
+        // 3. Fallback: If API empty (or failed), load from LocalStorage
+        const savedItems = localStorage.getItem("tracker_items");
+        const savedEvents = localStorage.getItem("tracker_events");
+
+        let localItems: TrackerItem[] = [];
+        let localEvents: TrackerEvent[] = [];
+
+        if (savedItems) {
+          try {
+            localItems = JSON.parse(savedItems);
+          } catch (e) {
+            console.error("Failed to parse local tracker_items", e);
+          }
+        }
+
+        if (savedEvents) {
+          try {
+            localEvents = JSON.parse(savedEvents);
+          } catch (e) {
+            console.error("Failed to parse local tracker_events", e);
+          }
+        }
+
+        // 4. MIGRATION: If we have local data but API was empty, sync to backend
+        if ((localItems.length > 0 || localEvents.length > 0) && response.ok) {
+          console.log("Migrating local data to backend...");
+
+          if (localItems.length > 0) {
+            await fetch("/api/tracker", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ action: "sync_items", data: localItems }),
+            });
+          }
+
+          if (localEvents.length > 0) {
+            await fetch("/api/tracker", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                action: "sync_events",
+                data: localEvents,
+              }),
+            });
+          }
+
+          // After sync, setting state from local is fine as it matches backend now
+        }
+
+        setTrackedItems(localItems);
+        setEvents(localEvents);
+      } catch (error) {
+        console.error("Failed to initialize tracker:", error);
+
+        try {
+          const savedItems = localStorage.getItem("tracker_items");
+          if (savedItems) setTrackedItems(JSON.parse(savedItems));
+        } catch (e) {
+          console.error("Failed to recover from local storage", e);
+        }
+      } finally {
+        setIsLoaded(true);
+      }
+    };
+
+    initializeTracker();
+  }, []);
+
+  // Helper to sync state changes to API (Optimistic updates)
+  const syncItemToBackend = async (item: TrackerItem) => {
+    try {
+      await fetch("/api/tracker", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "add_item", data: item }),
+      });
+    } catch (e) {
+      console.error("Failed to sync item", e);
+      toast.error("Failed to save changes to cloud");
+    }
+  };
+
+  const syncStatusToBackend = async (
+    oppId: string | number,
+    status: string,
+    extraData?: Record<string, unknown>
+  ) => {
+    try {
+      await fetch("/api/tracker", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "update_status",
+          id: oppId,
+          data: { status, ...extraData },
+        }),
+      });
+    } catch (e) {
+      console.error("Failed to sync status", e);
+    }
+  };
+
+  const deleteFromBackend = async (
+    id: string | number,
+    type: "item" | "event"
+  ) => {
+    try {
+      await fetch(`/api/tracker?type=${type}&id=${id}`, { method: "DELETE" });
+    } catch (e) {
+      console.error("Failed to delete from backend", e);
+    }
+  };
+
+  // Persistence (Keep LocalStorage as backup/cache)
+  useEffect(() => {
+    if (isLoaded)
+      localStorage.setItem("tracker_items", JSON.stringify(trackedItems));
+  }, [trackedItems, isLoaded]);
+
+  useEffect(() => {
+    if (isLoaded)
+      localStorage.setItem("tracker_events", JSON.stringify(events));
+  }, [events, isLoaded]);
+
+  // Hydrate Data from API
+  useEffect(() => {
+    const fetchDetails = async () => {
+      if (!isLoaded || trackedItems.length === 0) {
+        setHydratedItems([]);
+        return;
+      }
+
+      // Avoid hydration if items are already fully hydrated (unlikely but possible optimization)
+      // For now, we always hydrate to get latest company info/logos etc.
+
+      setIsFetching(true);
+      try {
+        // Separate IDs by kind
+        const internshipIds = trackedItems
+          .filter((i) => (i.kind || "internship") === "internship")
+          .map((i) => i.oppId as string);
+
+        const opportunityIds = trackedItems
+          .filter(
+            (i) => i.kind === "opportunity" && typeof i.oppId === "string"
+          )
+          .map((i) => i.oppId as string);
+
+        // Fetch in parallel
+        const [internshipData, opportunityData] = await Promise.all([
+          internshipIds.length > 0
+            ? fetchInternshipsPaginated(
+                100,
+                0,
+                undefined,
+                [],
+                [],
+                undefined,
+                undefined,
+                undefined,
+                internshipIds
+              )
+            : Promise.resolve({ internships: [] }),
+          opportunityIds.length > 0
+            ? fetchOpportunitiesPaginated(
+                100,
+                0,
+                undefined,
+                [],
+                [],
+                opportunityIds
+              )
+            : Promise.resolve({ opportunities: [] }),
+        ]);
+
+        // Create lookups
+        const internshipsMap = new Map(
+          internshipData.internships.map((i: Internship) => [i.id, i])
+        );
+        const opportunitiesMap = new Map(
+          (opportunityData.opportunities || []).map((o: Opportunity) => [
+            o.id,
+            o,
+          ])
+        );
+
+        let opportunityStorage: ReturnType<
+          typeof createOpportunityStorage
+        > | null = null;
+        const bucketId =
+          process.env.NEXT_PUBLIC_APPWRITE_OPPORTUNITIES_BUCKET_ID;
+        if (bucketId) {
+          try {
+            opportunityStorage = createOpportunityStorage();
+          } catch (e) {
+            console.error("Failed to init storage", e);
+          }
+        }
+
+        const getImageUrl = (
+          imageId: string | undefined
+        ): string | undefined => {
+          if (!imageId) return undefined;
+          if (imageId.startsWith("http") || imageId.startsWith("/"))
+            return imageId;
+          if (opportunityStorage && bucketId) {
             try {
-                // 1. Fetch from API
-                const response = await fetch('/api/tracker');
-
-                if (response.ok) {
-                    const data = await response.json();
-
-                    // 2. Check if API has data
-                    if (data.items && data.items.length > 0) {
-                        setTrackedItems(data.items);
-                        setEvents(data.events || []);
-                        setIsLoaded(true);
-                        return; // API is source of truth
-                    }
-                }
-
-                // 3. Fallback: If API empty (or failed), load from LocalStorage
-                const savedItems = localStorage.getItem('tracker_items');
-                const savedEvents = localStorage.getItem('tracker_events');
-
-                let localItems: TrackerItem[] = [];
-                let localEvents: TrackerEvent[] = [];
-
-                if (savedItems) {
-                    try {
-                        localItems = JSON.parse(savedItems);
-                    } catch (e) {
-                        console.error("Failed to parse local tracker_items", e);
-                    }
-                }
-
-                if (savedEvents) {
-                    try {
-                        localEvents = JSON.parse(savedEvents);
-                    } catch (e) {
-                        console.error("Failed to parse local tracker_events", e);
-                    }
-                }
-
-                // 4. MIGRATION: If we have local data but API was empty, sync to backend
-                if ((localItems.length > 0 || localEvents.length > 0) && response.ok) {
-                    console.log("Migrating local data to backend...");
-
-                    if (localItems.length > 0) {
-                        await fetch('/api/tracker', {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ action: 'sync_items', data: localItems })
-                        });
-                    }
-
-                    if (localEvents.length > 0) {
-                        await fetch('/api/tracker', {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ action: 'sync_events', data: localEvents })
-                        });
-                    }
-
-                    // After sync, setting state from local is fine as it matches backend now
-                }
-
-                setTrackedItems(localItems);
-                setEvents(localEvents);
-
-            } catch (error) {
-                console.error('Failed to initialize tracker:', error);
-
-                try {
-                    const savedItems = localStorage.getItem('tracker_items');
-                    if (savedItems) setTrackedItems(JSON.parse(savedItems));
-                } catch (e) {
-                    console.error("Failed to recover from local storage", e);
-                }
-
-            } finally {
-                setIsLoaded(true);
+              return opportunityStorage
+                .getFileView(bucketId, imageId)
+                .toString();
+            } catch {
+              return imageId;
             }
+          }
+          return imageId;
         };
 
-        initializeTracker();
-    }, []);
+        // Merge Data
+        const merged = trackedItems.map((item) => {
+          let apiData: Partial<TrackerItem> = {};
 
-    // Helper to sync state changes to API (Optimistic updates)
-    const syncItemToBackend = async (item: TrackerItem) => {
-        try {
-            await fetch('/api/tracker', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ action: 'add_item', data: item })
-            });
-        } catch (e) {
-            console.error("Failed to sync item", e);
-            toast.error("Failed to save changes to cloud");
-        }
-    };
-
-    const syncStatusToBackend = async (oppId: string | number, status: string, extraData?: Record<string, unknown>) => {
-        try {
-            await fetch('/api/tracker', {
-                method: 'PATCH',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ action: 'update_status', id: oppId, data: { status, ...extraData } })
-            });
-        } catch (e) {
-            console.error("Failed to sync status", e);
-        }
-    }
-
-    const deleteFromBackend = async (id: string | number, type: 'item' | 'event') => {
-        try {
-            await fetch(`/api/tracker?type=${type}&id=${id}`, { method: 'DELETE' });
-        } catch (e) {
-            console.error("Failed to delete from backend", e);
-        }
-    }
-
-
-    // Persistence (Keep LocalStorage as backup/cache)
-    useEffect(() => {
-        if (isLoaded) localStorage.setItem('tracker_items', JSON.stringify(trackedItems));
-    }, [trackedItems, isLoaded]);
-
-    useEffect(() => {
-        if (isLoaded) localStorage.setItem('tracker_events', JSON.stringify(events));
-    }, [events, isLoaded]);
-
-    // Hydrate Data from API
-    useEffect(() => {
-        const fetchDetails = async () => {
-            if (!isLoaded || trackedItems.length === 0) {
-                setHydratedItems([]);
-                return;
+          if ((item.kind || "internship") === "internship") {
+            const fetched = internshipsMap.get(item.oppId as string);
+            if (fetched) {
+              apiData = {
+                title: fetched.title,
+                company: fetched.hiringOrganization,
+                location: fetched.location,
+                type: fetched.type,
+                deadline: fetched.deadline,
+                logo: undefined, // Internship uses 'poster' (was removed)
+                ...fetched,
+              };
             }
-
-            // Avoid hydration if items are already fully hydrated (unlikely but possible optimization)
-            // For now, we always hydrate to get latest company info/logos etc.
-
-            setIsFetching(true);
-            try {
-                // Separate IDs by kind
-                const internshipIds = trackedItems
-                    .filter(i => (i.kind || 'internship') === 'internship')
-                    .map(i => i.oppId as string);
-
-                const opportunityIds = trackedItems
-                    .filter(i => i.kind === 'opportunity' && typeof i.oppId === 'string')
-                    .map(i => i.oppId as string);
-
-                // Fetch in parallel
-                const [internshipData, opportunityData] = await Promise.all([
-                    internshipIds.length > 0 ? fetchInternshipsPaginated(100, 0, undefined, [], [], undefined, undefined, undefined, internshipIds) : Promise.resolve({ internships: [] }),
-                    opportunityIds.length > 0 ? fetchOpportunitiesPaginated(100, 0, undefined, [], [], opportunityIds) : Promise.resolve({ opportunities: [] })
-                ]);
-
-                // Create lookups
-                const internshipsMap = new Map(internshipData.internships.map((i: Internship) => [i.id, i]));
-                const opportunitiesMap = new Map((opportunityData.opportunities || []).map((o: Opportunity) => [o.id, o]));
-
-                let opportunityStorage: ReturnType<typeof createOpportunityStorage> | null = null;
-                const bucketId = process.env.NEXT_PUBLIC_APPWRITE_OPPORTUNITIES_BUCKET_ID;
-                if (bucketId) {
-                    try {
-                        opportunityStorage = createOpportunityStorage();
-                    } catch (e) {
-                        console.error('Failed to init storage', e);
-                    }
-                }
-
-                const getImageUrl = (imageId: string | undefined): string | undefined => {
-                    if (!imageId) return undefined;
-                    if (imageId.startsWith('http') || imageId.startsWith('/')) return imageId;
-                    if (opportunityStorage && bucketId) {
-                        try {
-                            return opportunityStorage.getFileView(bucketId, imageId).toString();
-                        } catch {
-                            return imageId;
-                        }
-                    }
-                    return imageId;
-                };
-
-                // Merge Data
-                const merged = trackedItems.map(item => {
-                    let apiData: Partial<TrackerItem> = {};
-
-                    if ((item.kind || 'internship') === 'internship') {
-                        const fetched = internshipsMap.get(item.oppId as string);
-                        if (fetched) {
-                            apiData = {
-                                title: fetched.title,
-                                company: fetched.hiringOrganization,
-                                location: fetched.location,
-                                type: fetched.type,
-                                deadline: fetched.deadline,
-                                logo: undefined, // Internship uses 'poster' (was removed)
-                                ...fetched
-                            };
-                        }
-                    } else if (item.kind === 'opportunity') {
-                        const fetched = opportunitiesMap.get(item.oppId as string);
-                        if (fetched) {
-                            apiData = {
-                                title: fetched.title,
-                                company: fetched.organiserInfo || 'Organizer', // Opportunities use organiserInfo
-                                location: fetched.location,
-                                type: fetched.type,
-                                deadline: fetched.endDate || fetched.startDate, // Use endDate as deadline
-                                logo: getImageUrl(fetched.images?.[0]), // Use first image if available, resolving to URL
-                                ...fetched
-                            };
-                        }
-                    }
-
-                    if (Object.keys(apiData).length === 0) {
-                        return item;
-                    }
-
-                    return {
-                        ...apiData,
-                        ...item, // Keep local status, notes, etc.
-                        title: apiData.title || item.title, // Prefer API title
-                        company: apiData.company || item.company,
-                        logo: apiData.logo || item.logo, // Prefer API logo
-                    };
-                });
-
-                setHydratedItems(merged);
-
-            } catch (error) {
-                console.error("Failed to hydrate tracker items", error);
-                setHydratedItems(trackedItems);
-            } finally {
-                setIsFetching(false);
+          } else if (item.kind === "opportunity") {
+            const fetched = opportunitiesMap.get(item.oppId as string);
+            if (fetched) {
+              apiData = {
+                title: fetched.title,
+                company: fetched.organiserInfo || "Organizer", // Opportunities use organiserInfo
+                location: fetched.location,
+                type: fetched.type,
+                deadline: fetched.endDate || fetched.startDate, // Use endDate as deadline
+                logo: getImageUrl(fetched.images?.[0]), // Use first image if available, resolving to URL
+                ...fetched,
+              };
             }
-        };
+          }
 
-        const timeout = setTimeout(fetchDetails, 100);
-        return () => clearTimeout(timeout);
+          if (Object.keys(apiData).length === 0) {
+            return item;
+          }
 
-    }, [trackedItems, isLoaded]);
-
-    const addEvent = (event: Omit<TrackerEvent, 'id'>) => {
-        const optimisticId = Date.now().toString(); // Use string ID
-        const newItem = { ...event, id: optimisticId };
-        setEvents(prev => [...prev, newItem]);
-        toast.success(`📅 Event Added: ${event.title}`);
-
-        // Backend Sync
-        fetch('/api/tracker', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ action: 'add_event', data: event })
-        })
-            .then(res => res.json())
-            .then(data => {
-                if (data.success && data.event) {
-                    // Update with backend ID
-                    setEvents(prev => prev.map(e => e.id === optimisticId ? { ...e, id: data.event.id } : e));
-                }
-            })
-            .catch(err => console.error("Event sync failed", err));
-    };
-
-    const removeEvent = (id: string) => {
-        setEvents(prev => prev.filter(e => e.id !== id));
-        deleteFromBackend(id, 'event');
-    };
-
-    const addToTracker = (oppOrId: number | string | ManualTrackerInput, initialStatus = 'Not Applied', kind: 'internship' | 'opportunity' = 'internship') => {
-        const isManual = typeof oppOrId === 'object';
-        const idToCheck = isManual
-            ? (oppOrId as ManualTrackerInput).id ?? Date.now()
-            : (oppOrId as number | string);
-
-        const isAlreadyAdded = trackedItems.some(i => String(i.oppId) === String(idToCheck));
-
-        if (isAlreadyAdded) {
-            toast.info("Already in Tracker");
-            return;
-        }
-
-        if (initialStatus === 'Not Applied') {
-            toast.success("Saved to Tracker");
-        } else if (initialStatus === 'Draft') {
-            toast.success("Draft Saved");
-        }
-
-        let newItem: TrackerItem;
-
-        setTrackedItems(prevItems => {
-            if (prevItems.some(i => String(i.oppId) === String(idToCheck))) {
-                return prevItems;
-            }
-
-            const inputData = isManual ? (oppOrId as ManualTrackerInput) : {};
-
-            newItem = {
-                oppId: idToCheck,
-                status: initialStatus,
-                kind: (isManual && (oppOrId as ManualTrackerInput).kind) ? (oppOrId as ManualTrackerInput).kind : kind,
-                addedAt: new Date().toISOString(),
-                appliedAt: initialStatus === 'Applied' ? new Date().toISOString() : null,
-                result: null,
-                notes: inputData.notes || '',
-                draftData: (isManual && (oppOrId as ManualTrackerInput).draftData) ? (oppOrId as ManualTrackerInput).draftData : null,
-                ...inputData
-            } as TrackerItem;
-
-            // Trigger sync (side effect inside setter is bad practice usually, but doing it after calculation)
-            setTimeout(() => syncItemToBackend(newItem), 0);
-
-            return [...prevItems, newItem];
+          return {
+            ...apiData,
+            ...item, // Keep local status, notes, etc.
+            title: apiData.title || item.title, // Prefer API title
+            company: apiData.company || item.company,
+            logo: apiData.logo || item.logo, // Prefer API logo
+          };
         });
+
+        setHydratedItems(merged);
+      } catch (error) {
+        console.error("Failed to hydrate tracker items", error);
+        setHydratedItems(trackedItems);
+      } finally {
+        setIsFetching(false);
+      }
     };
 
-    const updateStatus = (oppId: number | string, status: string, extraData: Record<string, unknown> = {}) => {
-        setTrackedItems(prevItems => prevItems.map(i => {
-            if (String(i.oppId) === String(oppId)) { // String comparison
-                const updated = {
-                    ...i,
-                    ...extraData,
-                    status,
-                    updatedAt: new Date().toISOString()
-                };
-                return updated;
-            }
-            return i;
-        }));
+    const timeout = setTimeout(fetchDetails, 100);
+    return () => clearTimeout(timeout);
+  }, [trackedItems, isLoaded]);
 
-        syncStatusToBackend(oppId, status, extraData);
-    };
+  const addEvent = (event: Omit<TrackerEvent, "id">) => {
+    const optimisticId = Date.now().toString(); // Use string ID
+    const newItem = { ...event, id: optimisticId };
+    setEvents((prev) => [...prev, newItem]);
+    toast.success(`📅 Event Added: ${event.title}`);
 
-    const removeFromTracker = (oppId: number | string) => {
-        setTrackedItems(prevItems => prevItems.filter(i => String(i.oppId) !== String(oppId))); // String comparison
-        toast.success("Deleted from Tracker");
-        deleteFromBackend(oppId, 'item');
-    };
+    // Backend Sync
+    fetch("/api/tracker", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "add_event", data: event }),
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.success && data.event) {
+          // Update with backend ID
+          setEvents((prev) =>
+            prev.map((e) =>
+              e.id === optimisticId ? { ...e, id: data.event.id } : e
+            )
+          );
+        }
+      })
+      .catch((err) => console.error("Event sync failed", err));
+  };
 
-    const getStatus = (oppId: number | string) => {
-        const item = trackedItems.find(i => String(i.oppId) === String(oppId)); // String comparison
-        return item ? item.status : null;
-    };
+  const removeEvent = (id: string) => {
+    setEvents((prev) => prev.filter((e) => e.id !== id));
+    deleteFromBackend(id, "event");
+  };
 
-    return (
-        <TrackerContext.Provider value={{
-            items: hydratedItems.length > 0 ? hydratedItems : trackedItems,
-            events,
-            addToTracker,
-            removeFromTracker,
-            updateStatus,
-            getStatus,
-            addEvent,
-            removeEvent,
-            isLoading: !isLoaded || isFetching
-        }}>
-            {children}
-        </TrackerContext.Provider>
+  const addToTracker = (
+    oppOrId: number | string | ManualTrackerInput,
+    initialStatus = "Not Applied",
+    kind: "internship" | "opportunity" = "internship"
+  ) => {
+    const isManual = typeof oppOrId === "object";
+    const idToCheck = isManual
+      ? ((oppOrId as ManualTrackerInput).id ?? Date.now())
+      : (oppOrId as number | string);
+
+    const isAlreadyAdded = trackedItems.some(
+      (i) => String(i.oppId) === String(idToCheck)
     );
+
+    if (isAlreadyAdded) {
+      toast.info("Already in Tracker");
+      return;
+    }
+
+    if (initialStatus === "Not Applied") {
+      toast.success("Saved to Tracker");
+    } else if (initialStatus === "Draft") {
+      toast.success("Draft Saved");
+    }
+
+    let newItem: TrackerItem;
+
+    setTrackedItems((prevItems) => {
+      if (prevItems.some((i) => String(i.oppId) === String(idToCheck))) {
+        return prevItems;
+      }
+
+      const inputData = isManual ? (oppOrId as ManualTrackerInput) : {};
+
+      newItem = {
+        oppId: idToCheck,
+        status: initialStatus,
+        kind:
+          isManual && (oppOrId as ManualTrackerInput).kind
+            ? (oppOrId as ManualTrackerInput).kind
+            : kind,
+        addedAt: new Date().toISOString(),
+        appliedAt:
+          initialStatus === "Applied" ? new Date().toISOString() : null,
+        result: null,
+        notes: inputData.notes || "",
+        draftData:
+          isManual && (oppOrId as ManualTrackerInput).draftData
+            ? (oppOrId as ManualTrackerInput).draftData
+            : null,
+        ...inputData,
+      } as TrackerItem;
+
+      // Trigger sync (side effect inside setter is bad practice usually, but doing it after calculation)
+      setTimeout(() => syncItemToBackend(newItem), 0);
+
+      return [...prevItems, newItem];
+    });
+  };
+
+  const updateStatus = (
+    oppId: number | string,
+    status: string,
+    extraData: Record<string, unknown> = {}
+  ) => {
+    setTrackedItems((prevItems) =>
+      prevItems.map((i) => {
+        if (String(i.oppId) === String(oppId)) {
+          // String comparison
+          const updated = {
+            ...i,
+            ...extraData,
+            status,
+            updatedAt: new Date().toISOString(),
+          };
+          return updated;
+        }
+        return i;
+      })
+    );
+
+    syncStatusToBackend(oppId, status, extraData);
+  };
+
+  const removeFromTracker = (oppId: number | string) => {
+    setTrackedItems((prevItems) =>
+      prevItems.filter((i) => String(i.oppId) !== String(oppId))
+    ); // String comparison
+    toast.success("Deleted from Tracker");
+    deleteFromBackend(oppId, "item");
+  };
+
+  const getStatus = (oppId: number | string) => {
+    const item = trackedItems.find((i) => String(i.oppId) === String(oppId)); // String comparison
+    return item ? item.status : null;
+  };
+
+  return (
+    <TrackerContext.Provider
+      value={{
+        items: hydratedItems.length > 0 ? hydratedItems : trackedItems,
+        events,
+        addToTracker,
+        removeFromTracker,
+        updateStatus,
+        getStatus,
+        addEvent,
+        removeEvent,
+        isLoading: !isLoaded || isFetching,
+      }}
+    >
+      {children}
+    </TrackerContext.Provider>
+  );
 };

--- a/components/tracker/EventCard.tsx
+++ b/components/tracker/EventCard.tsx
@@ -1,64 +1,90 @@
 "use client";
 
-import React from 'react';
-import { Calendar, Clock, Video, X, AlertCircle } from 'lucide-react';
-import { cn } from '@/lib/utils';
-import { TrackerEvent } from '../providers/TrackerProvider';
+import React from "react";
+import { Calendar, Clock, Video, X, AlertCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { TrackerEvent } from "../providers/TrackerProvider";
+import { format } from "date-fns";
+
+function formatDateDDMMYYYY(dateText: string) {
+  const parsedDate = new Date(dateText);
+  if (Number.isNaN(parsedDate.getTime())) {
+    return dateText;
+  }
+
+  return format(parsedDate, "dd/MM/yyyy");
+}
 
 interface EventCardProps {
-    event: TrackerEvent;
-    onDelete: (id: string) => void;
+  event: TrackerEvent;
+  onDelete: (id: string) => void;
 }
 
 export default function EventCard({ event, onDelete }: EventCardProps) {
-    const isDeadline = event.type === 'Deadline';
-    const isInterview = event.type === 'Interview';
+  const isDeadline = event.type === "Deadline";
+  const isInterview = event.type === "Interview";
 
-    // Colors based on type
-    const getTheme = () => {
-        if (isInterview) return 'bg-purple-50 border-purple-200 text-purple-900';
-        if (isDeadline) return 'bg-amber-50 border-amber-200 text-amber-900';
-        return 'bg-slate-50 border-slate-200 text-slate-900';
-    };
+  // Colors based on type
+  const getTheme = () => {
+    if (isInterview) return "bg-purple-50 border-purple-200 text-purple-900";
+    if (isDeadline) return "bg-amber-50 border-amber-200 text-amber-900";
+    return "bg-slate-50 border-slate-200 text-slate-900";
+  };
 
-    const getIcon = () => {
-        if (isInterview) return Video;
-        if (isDeadline) return AlertCircle;
-        return Calendar;
-    };
+  const getIcon = () => {
+    if (isInterview) return Video;
+    if (isDeadline) return AlertCircle;
+    return Calendar;
+  };
 
-    const Icon = getIcon();
+  const Icon = getIcon();
 
-    return (
-        <div className={cn("p-4 rounded-xl border flex items-start gap-4 group relative", getTheme())}>
-            <div className={cn("p-2 rounded-lg bg-white/60", isInterview ? "text-purple-600" : isDeadline ? "text-amber-600" : "text-slate-600")}>
-                <Icon size={20} />
-            </div>
+  return (
+    <div
+      className={cn(
+        "group relative flex items-start gap-4 rounded-xl border p-4",
+        getTheme()
+      )}
+    >
+      <div
+        className={cn(
+          "rounded-lg bg-white/60 p-2",
+          isInterview
+            ? "text-purple-600"
+            : isDeadline
+              ? "text-amber-600"
+              : "text-slate-600"
+        )}
+      >
+        <Icon size={20} />
+      </div>
 
-            <div className="flex-1 min-w-0">
-                <div className="flex justify-between items-start">
-                    <h4 className="font-bold text-sm truncate pr-6">{event.title}</h4>
-                </div>
-
-                <div className="flex items-center gap-3 mt-1 text-xs opacity-80 font-medium">
-                    <div className="flex items-center gap-1">
-                        <Clock size={12} />
-                        {new Date(event.date).toLocaleDateString()}
-                    </div>
-                </div>
-
-                {event.description && (
-                    <p className="text-xs mt-2 opacity-70 line-clamp-2">{event.description}</p>
-                )}
-            </div>
-
-            <button
-                onClick={() => onDelete(event.id)}
-                aria-label="Delete event"
-                className="absolute top-2 right-2 p-1.5 text-slate-400 hover:text-slate-600 hover:bg-black/5 rounded-full opacity-0 group-hover:opacity-100 focus:opacity-100 focus:ring-2 focus:ring-slate-400 transition-all outline-none"
-            >
-                <X size={14} aria-hidden="true" />
-            </button>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-start justify-between">
+          <h4 className="truncate pr-6 text-sm font-bold">{event.title}</h4>
         </div>
-    );
+
+        <div className="mt-1 flex items-center gap-3 text-xs font-medium opacity-80">
+          <div className="flex items-center gap-1">
+            <Clock size={12} />
+            {formatDateDDMMYYYY(event.date)}
+          </div>
+        </div>
+
+        {event.description && (
+          <p className="mt-2 line-clamp-2 text-xs opacity-70">
+            {event.description}
+          </p>
+        )}
+      </div>
+
+      <button
+        onClick={() => onDelete(event.id)}
+        aria-label="Delete event"
+        className="absolute top-2 right-2 rounded-full p-1.5 text-slate-400 opacity-0 transition-all outline-none group-hover:opacity-100 hover:bg-black/5 hover:text-slate-600 focus:opacity-100 focus:ring-2 focus:ring-slate-400"
+      >
+        <X size={14} aria-hidden="true" />
+      </button>
+    </div>
+  );
 }

--- a/components/tracker/MobileTrackerCard.tsx
+++ b/components/tracker/MobileTrackerCard.tsx
@@ -1,111 +1,210 @@
-import React from 'react';
-import { Trash2, ChevronDown } from 'lucide-react';
-import { toast } from 'sonner';
-import { TrackerItem } from '@/components/providers/TrackerProvider';
-import { differenceInCalendarDays } from 'date-fns';
+import React from "react";
+import {
+  CalendarCheck,
+  CalendarPlus2,
+  ChevronDown,
+  Trash2,
+} from "lucide-react";
+import { toast } from "sonner";
+import { TrackerItem } from "@/components/providers/TrackerProvider";
+import { differenceInCalendarDays, format } from "date-fns";
+
+function formatDateDDMMYYYY(dateText: string) {
+  const parsedDate = new Date(dateText);
+  if (Number.isNaN(parsedDate.getTime())) {
+    return dateText;
+  }
+
+  return format(parsedDate, "dd/MM/yyyy");
+}
 
 function DeadlineBadge({ deadline }: { deadline: string }) {
-    const daysDiff = differenceInCalendarDays(new Date(deadline), new Date());
-    if (daysDiff < 0) return <span className="text-[10px] font-bold bg-red-50 text-red-600 border border-red-200 px-2 py-0.5 rounded-full">Closed</span>;
-    if (daysDiff === 0) return <span className="text-[10px] font-bold bg-orange-50 text-orange-600 border border-orange-200 px-2 py-0.5 rounded-full animate-pulse">Today!</span>;
-    if (daysDiff <= 3) return <span className="text-[10px] font-bold bg-rose-50 text-rose-600 border border-rose-200 px-2 py-0.5 rounded-full">{daysDiff}d left</span>;
-    if (daysDiff <= 7) return <span className="text-[10px] font-bold bg-amber-50 text-amber-600 border border-amber-200 px-2 py-0.5 rounded-full">{daysDiff} days left</span>;
-    return <span className="text-[10px] font-bold bg-green-50 text-green-600 border border-green-200 px-2 py-0.5 rounded-full">{daysDiff} days left</span>;
+  const daysDiff = differenceInCalendarDays(new Date(deadline), new Date());
+  if (daysDiff < 0)
+    return (
+      <span className="rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[10px] font-bold text-red-600">
+        Closed
+      </span>
+    );
+  if (daysDiff === 0)
+    return (
+      <span className="animate-pulse rounded-full border border-orange-200 bg-orange-50 px-2 py-0.5 text-[10px] font-bold text-orange-600">
+        Today!
+      </span>
+    );
+  if (daysDiff <= 3)
+    return (
+      <span className="rounded-full border border-rose-200 bg-rose-50 px-2 py-0.5 text-[10px] font-bold text-rose-600">
+        {daysDiff}d left
+      </span>
+    );
+  if (daysDiff <= 7)
+    return (
+      <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[10px] font-bold text-amber-600">
+        {daysDiff} days left
+      </span>
+    );
+  return (
+    <span className="rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-[10px] font-bold text-green-600">
+      {daysDiff} days left
+    </span>
+  );
 }
 
 interface MobileTrackerCardProps {
-    opp: TrackerItem;
-    updateStatus: (id: number | string, status: string, extraData?: Record<string, unknown>) => void;
-    onDelete: (id: number | string) => void;
-    onClick: (opp: TrackerItem) => void;
+  opp: TrackerItem;
+  updateStatus: (
+    id: number | string,
+    status: string,
+    extraData?: Record<string, unknown>
+  ) => void;
+  onDelete: (id: number | string) => void;
+  onClick: (opp: TrackerItem) => void;
+  onAddToCalendar: (opp: TrackerItem) => void;
+  isCalendarAdded: boolean;
+  isCalendarAdding: boolean;
 }
 
-export default function MobileTrackerCard({ opp, updateStatus, onDelete, onClick }: MobileTrackerCardProps) {
-    const statuses = ['Not Applied', 'Applied', 'Result Awaited', 'Selected', 'Rejected'];
+export default function MobileTrackerCard({
+  opp,
+  updateStatus,
+  onDelete,
+  onClick,
+  onAddToCalendar,
+  isCalendarAdded,
+  isCalendarAdding,
+}: MobileTrackerCardProps) {
+  const statuses = [
+    "Not Applied",
+    "Applied",
+    "Result Awaited",
+    "Selected",
+    "Rejected",
+  ];
 
-    const handleStatusChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-        const newStatus = e.target.value;
-        if (newStatus === 'Rejected') {
-            const reason = prompt("What do you think was the reason? (Resume, Interview, Ghosted?)");
-            if (reason) {
-                updateStatus(opp.oppId, newStatus, { failureReason: reason });
-                toast.message("💡 Suggestion", {
-                    description: reason.toLowerCase().includes('resume') ? "Check out the Resume Toolkit." : "Try the Mock Interview tool.",
-                });
-            } else {
-                updateStatus(opp.oppId, newStatus);
-            }
-        } else {
-            updateStatus(opp.oppId, newStatus);
-        }
-    };
+  const handleStatusChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newStatus = e.target.value;
+    if (newStatus === "Rejected") {
+      const reason = prompt(
+        "What do you think was the reason? (Resume, Interview, Ghosted?)"
+      );
+      if (reason) {
+        updateStatus(opp.oppId, newStatus, { failureReason: reason });
+        toast.message("💡 Suggestion", {
+          description: reason.toLowerCase().includes("resume")
+            ? "Check out the Resume Toolkit."
+            : "Try the Mock Interview tool.",
+        });
+      } else {
+        updateStatus(opp.oppId, newStatus);
+      }
+    } else {
+      updateStatus(opp.oppId, newStatus);
+    }
+  };
 
-    return (
-        <div
-            onClick={() => onClick(opp)}
-            className="p-4 border-b border-slate-100 bg-white relative cursor-pointer active:bg-slate-50 transition-colors group"
-        >
-            {/* Top Row: Logo, Info, and Delete */}
-            <div className="flex justify-between items-start mb-4">
-                <div className="flex items-center gap-3 pr-2 min-w-0 flex-1">
-                    {(opp.logo || opp.poster || opp.images?.[0]) ? (
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img src={opp.logo || opp.poster || opp.images?.[0]} alt={opp.company} className="w-10 h-10 rounded-lg object-contain bg-white border border-slate-100 p-0.5 shrink-0" />
-                    ) : (
-                        <div className="w-10 h-10 bg-slate-100 rounded-lg flex items-center justify-center text-slate-500 font-bold text-sm shrink-0">
-                            {opp.company ? opp.company.charAt(0) : '?'}
-                        </div>
-                    )}
-                    <div className="min-w-0">
-                        <h4 className="font-bold text-slate-900 text-base leading-tight mb-0.5 truncate pr-1">{opp.title}</h4>
-                        <p className="text-slate-500 text-xs font-medium truncate">{opp.company}</p>
-                    </div>
-                </div>
-
-                <button
-                    onClick={(e) => { e.stopPropagation(); onDelete(opp.oppId); }}
-                    className="p-2 text-rose-500 hover:text-rose-600 hover:bg-rose-50 rounded-lg shrink-0 transition-colors"
-                    title="Delete"
-                >
-                    <Trash2 size={18} />
-                </button>
+  return (
+    <div
+      onClick={() => onClick(opp)}
+      className="group relative cursor-pointer border-b border-slate-100 bg-white p-4 transition-colors active:bg-slate-50"
+    >
+      {/* Top Row: Logo, Info, and Delete */}
+      <div className="mb-4 flex items-start justify-between">
+        <div className="flex min-w-0 flex-1 items-center gap-3 pr-2">
+          {opp.logo || opp.poster || opp.images?.[0] ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={opp.logo || opp.poster || opp.images?.[0]}
+              alt={opp.company}
+              className="h-10 w-10 shrink-0 rounded-lg border border-slate-100 bg-white object-contain p-0.5"
+            />
+          ) : (
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-slate-100 text-sm font-bold text-slate-500">
+              {opp.company ? opp.company.charAt(0) : "?"}
             </div>
-
-            {/* Bottom Row: Status and Metadata */}
-            <div className="flex flex-wrap items-center justify-between gap-3 mt-1">
-                <div className="relative flex-1 min-w-[140px]" onClick={(e) => e.stopPropagation()}>
-                    <select
-                        value={opp.status}
-                        onChange={handleStatusChange}
-                        className="appearance-none bg-slate-50 border border-slate-200 rounded-xl text-xs font-bold text-slate-700 focus:outline-none focus:ring-2 focus:ring-orange-200 cursor-pointer w-full py-2 px-3 pr-8 transition-all"
-                    >
-                        {statuses.map(s => <option key={s} value={s}>{s}</option>)}
-                    </select>
-                    <ChevronDown size={14} className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none" />
-                </div>
-
-                <div className="flex items-center gap-2 shrink-0 ml-auto">
-                    {opp.deadline && (
-                        <div className="flex items-center gap-2 bg-slate-50 border border-slate-200 rounded-xl px-2 py-1.5">
-                            <a
-                                href={`https://www.google.com/calendar/render?action=TEMPLATE&text=Deadline: ${encodeURIComponent(opp.title)}&dates=${new Date(opp.deadline).toISOString().replace(/-|:|\.\d\d\d/g, "")}/${new Date(opp.deadline).toISOString().replace(/-|:|\.\d\d\d/g, "")}&details=Company: ${encodeURIComponent(opp.company)}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                onClick={(e) => e.stopPropagation()}
-                                className="text-slate-400 hover:text-blue-600 transition-colors shrink-0"
-                                title="Add to Google Calendar"
-                            >
-                                {/* eslint-disable-next-line @next/next/no-img-element */}
-                                <img src="/images/google-calendar.webp" alt="Google Calendar" className="w-4 h-4 object-contain" />
-                            </a>
-                            <span className="text-[10px] uppercase font-black tracking-wider text-slate-600 whitespace-nowrap">
-                                {new Date(opp.deadline).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
-                            </span>
-                            {opp.kind === 'opportunity' && <DeadlineBadge deadline={opp.deadline} />}
-                        </div>
-                    )}
-                </div>
-            </div>
+          )}
+          <div className="min-w-0">
+            <h4 className="mb-0.5 truncate pr-1 text-base leading-tight font-bold text-slate-900">
+              {opp.title}
+            </h4>
+            <p className="truncate text-xs font-medium text-slate-500">
+              {opp.company}
+            </p>
+          </div>
         </div>
-    );
+
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete(opp.oppId);
+          }}
+          className="shrink-0 rounded-lg p-2 text-rose-500 transition-colors hover:bg-rose-50 hover:text-rose-600"
+          title="Delete"
+        >
+          <Trash2 size={18} />
+        </button>
+      </div>
+
+      {/* Bottom Row: Status and Metadata */}
+      <div className="mt-1 flex flex-wrap items-center justify-between gap-3">
+        <div
+          className="relative min-w-[140px] flex-1"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <select
+            value={opp.status}
+            onChange={handleStatusChange}
+            className="w-full cursor-pointer appearance-none rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 pr-8 text-xs font-bold text-slate-700 transition-all focus:ring-2 focus:ring-orange-200 focus:outline-none"
+          >
+            {statuses.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+          <ChevronDown
+            size={14}
+            className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 text-slate-400"
+          />
+        </div>
+
+        <div className="ml-auto flex shrink-0 items-center gap-2">
+          {opp.deadline && (
+            <div className="flex items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-2 py-1.5">
+              <button
+                type="button"
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onAddToCalendar(opp);
+                }}
+                disabled={isCalendarAdding}
+                className="shrink-0 text-slate-400 transition-colors hover:text-blue-600"
+                title={
+                  isCalendarAdded
+                    ? "Added to Google Calendar"
+                    : "Add to Google Calendar"
+                }
+              >
+                {isCalendarAdded ? (
+                  <CalendarCheck size={16} className="text-emerald-600" />
+                ) : (
+                  <CalendarPlus2
+                    size={16}
+                    className={isCalendarAdding ? "animate-pulse" : ""}
+                  />
+                )}
+              </button>
+              <span className="text-[10px] font-black tracking-wider whitespace-nowrap text-slate-600 uppercase">
+                {formatDateDDMMYYYY(opp.deadline)}
+              </span>
+              {opp.kind === "opportunity" && (
+                <DeadlineBadge deadline={opp.deadline} />
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/components/tracker/Tracker.tsx
+++ b/components/tracker/Tracker.tsx
@@ -1,315 +1,690 @@
 "use client";
 
-import React, { useState, useMemo } from 'react';
-import { useTracker, TrackerItem } from '@/components/providers/TrackerProvider';
-import { FileText, TrendingUp, LucideIcon, Loader2, Activity, ChevronRight, X, Zap } from 'lucide-react';
-import { cn } from '@/lib/utils';
-import { motion, AnimatePresence } from 'framer-motion';
-import { useRouter, useSearchParams, usePathname } from 'next/navigation';
-import Link from 'next/link';
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  useTracker,
+  TrackerItem,
+} from "@/components/providers/TrackerProvider";
+import {
+  FileText,
+  TrendingUp,
+  LucideIcon,
+  Loader2,
+  Activity,
+  CalendarCog,
+  ChevronRight,
+  X,
+  Zap,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { motion, AnimatePresence } from "framer-motion";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import Link from "next/link";
+import { toast } from "sonner";
+import { authClient } from "@/lib/auth-client";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Switch } from "@/components/ui/switch";
 
+import TrackerDetailModal from "./TrackerDetailModal";
+import ApplyModal, { ApplyModalOpportunity } from "./ApplyModal";
 
-import TrackerDetailModal from './TrackerDetailModal';
-import ApplyModal, { ApplyModalOpportunity } from './ApplyModal';
-
-import TrackerRow from './TrackerRow';
-import MobileTrackerCard from './MobileTrackerCard';
-
-
+import TrackerRow from "./TrackerRow";
+import MobileTrackerCard from "./MobileTrackerCard";
 
 interface EnrichedTrackerItem extends TrackerItem {
-    isHighPriority: boolean;
+  isHighPriority: boolean;
 }
 
 interface MetricCardProps {
-    icon: LucideIcon;
-    label: string;
-    value: string | number;
-    color: string;
-    highlight?: boolean;
+  icon: LucideIcon;
+  label: string;
+  value: string | number;
+  color: string;
+  highlight?: boolean;
+}
+
+interface CalendarReminderSettings {
+  weekBefore: boolean;
+  dayBefore: boolean;
+  hourBefore: boolean;
 }
 
 export default function Tracker() {
-    const router = useRouter();
-    const searchParams = useSearchParams();
-    const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
 
-    // Helper for Priority
-    const isHighPriority = (deadline?: string) => {
-        if (!deadline) return false;
-        const diff = Math.ceil((new Date(deadline).getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24));
-        return diff >= 0 && diff <= 7;
-    };
+  // Helper for Priority
+  const isHighPriority = (deadline?: string) => {
+    if (!deadline) return false;
+    const diff = Math.ceil(
+      (new Date(deadline).getTime() - new Date().getTime()) /
+        (1000 * 60 * 60 * 24)
+    );
+    return diff >= 0 && diff <= 7;
+  };
 
-    const { items, updateStatus, removeFromTracker, isLoading } = useTracker();
+  const { items, updateStatus, removeFromTracker, isLoading } = useTracker();
 
-    const tabParam = searchParams.get('tab');
-    const initialTab = (tabParam === 'opportunity' || tabParam === 'internship') ? tabParam : 'internship';
-    const [activeTab, setActiveTab] = useState<'internship' | 'opportunity'>(initialTab);
+  const tabParam = searchParams.get("tab");
+  const initialTab =
+    tabParam === "opportunity" || tabParam === "internship"
+      ? tabParam
+      : "internship";
+  const [activeTab, setActiveTab] = useState<"internship" | "opportunity">(
+    initialTab
+  );
 
-    // Sync tab to URL when changed
-    const handleTabChange = (tab: 'internship' | 'opportunity') => {
-        setActiveTab(tab);
-        const params = new URLSearchParams(searchParams.toString());
-        params.set('tab', tab);
-        router.replace(`${pathname}?${params.toString()}`, { scroll: false });
-    };
+  useEffect(() => {
+    if (searchParams.get("calendar") === "connected") {
+      toast.success(
+        "Google Calendar connected. You can now add events in one click."
+      );
+      setIsCalendarConnected(true);
+      loadCalendarConfig();
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete("calendar");
+      router.replace(
+        params.toString() ? `${pathname}?${params.toString()}` : pathname,
+        { scroll: false }
+      );
+    }
+  }, [pathname, router, searchParams]);
 
+  // Sync tab to URL when changed
+  const handleTabChange = (tab: "internship" | "opportunity") => {
+    setActiveTab(tab);
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("tab", tab);
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+  };
 
-    const [detailOpp, setDetailOpp] = useState<TrackerItem | null>(null);
-    const [smartApplyOpp, setSmartApplyOpp] = useState<TrackerItem | null>(null);
-    const [showInsights, setShowInsights] = useState(false);
+  const [detailOpp, setDetailOpp] = useState<TrackerItem | null>(null);
+  const [smartApplyOpp, setSmartApplyOpp] = useState<TrackerItem | null>(null);
+  const [showInsights, setShowInsights] = useState(false);
+  const [isConnectingCalendar, setIsConnectingCalendar] = useState(false);
+  const [isCalendarConfigLoading, setIsCalendarConfigLoading] = useState(true);
+  const [isCalendarConnected, setIsCalendarConnected] = useState(false);
+  const [isSavingCalendarSettings, setIsSavingCalendarSettings] =
+    useState(false);
+  const [calendarReminderSettings, setCalendarReminderSettings] =
+    useState<CalendarReminderSettings>({
+      weekBefore: true,
+      dayBefore: true,
+      hourBefore: true,
+    });
+  const [calendarAddedByKey, setCalendarAddedByKey] = useState<
+    Record<string, boolean>
+  >({});
+  const [calendarAddingByKey, setCalendarAddingByKey] = useState<
+    Record<string, boolean>
+  >({});
 
+  const getCalendarKey = (opp: TrackerItem) =>
+    `${opp.oppId}:${opp.deadline || ""}`;
 
-    // Hydrate & Enhance Logic
-    const filteredItems = items.filter(i => (i.kind || 'internship') === activeTab);
+  const loadCalendarConfig = async () => {
+    try {
+      setIsCalendarConfigLoading(true);
+      const response = await fetch("/api/tracker/calendar", {
+        method: "GET",
+      });
 
-    const trackedOpps = useMemo(() => {
-        return filteredItems.map(item => {
-            // Data is already hydrated in Provider, just calculate priority
-            // For manual items that might miss some fields, we handle gracefully
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        return;
+      }
 
-            return {
-                ...item,
-                isHighPriority: isHighPriority(item.deadline)
-            } as EnrichedTrackerItem;
+      setIsCalendarConnected(!!data?.connected);
+      if (data?.reminders) {
+        setCalendarReminderSettings({
+          weekBefore: !!data.reminders.weekBefore,
+          dayBefore: !!data.reminders.dayBefore,
+          hourBefore: !!data.reminders.hourBefore,
         });
-    }, [filteredItems]);
+      }
+    } catch (error) {
+      console.error("Failed to load calendar config", error);
+    } finally {
+      setIsCalendarConfigLoading(false);
+    }
+  };
 
-    // Metrics Calculation
-    const total = trackedOpps.length;
+  const updateCalendarReminderSetting = async (
+    key: keyof CalendarReminderSettings,
+    checked: boolean
+  ) => {
+    const previousSettings = calendarReminderSettings;
+    const nextSettings = {
+      ...calendarReminderSettings,
+      [key]: checked,
+    };
 
-    // Total Applied: Everything where status is NOT 'Not Applied' and NOT 'Draft'
-    const totalApplications = trackedOpps.filter(i => i.status !== 'Not Applied' && i.status !== 'Draft').length;
-    const totalSelected = trackedOpps.filter(i => i.status === 'Selected').length;
+    setCalendarReminderSettings(nextSettings);
+    setIsSavingCalendarSettings(true);
 
-    const successRate = totalApplications > 0 ? Math.round((totalSelected / totalApplications) * 100) : 0;
-    const actionRate = total > 0 ? Math.round((totalApplications / total) * 100) : 0;
+    try {
+      const response = await fetch("/api/tracker/calendar", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(nextSettings),
+      });
 
+      if (!response.ok) {
+        setCalendarReminderSettings(previousSettings);
+        toast.error("Failed to save calendar notification settings.");
+      }
+    } catch (error) {
+      console.error("Failed to update calendar reminder settings", error);
+      setCalendarReminderSettings(previousSettings);
+      toast.error("Failed to save calendar notification settings.");
+    } finally {
+      setIsSavingCalendarSettings(false);
+    }
+  };
 
-    if (isLoading) {
-        return (
-            <div className="flex h-[50vh] w-full items-center justify-center">
-                <Loader2 className="animate-spin text-slate-400" size={32} />
-            </div>
-        );
+  useEffect(() => {
+    loadCalendarConfig();
+  }, []);
+
+  // Hydrate & Enhance Logic
+  const filteredItems = items.filter(
+    (i) => (i.kind || "internship") === activeTab
+  );
+
+  const trackedOpps = useMemo(() => {
+    return filteredItems.map((item) => {
+      // Data is already hydrated in Provider, just calculate priority
+      // For manual items that might miss some fields, we handle gracefully
+
+      return {
+        ...item,
+        isHighPriority: isHighPriority(item.deadline),
+      } as EnrichedTrackerItem;
+    });
+  }, [filteredItems]);
+
+  // Metrics Calculation
+  const total = trackedOpps.length;
+
+  // Total Applied: Everything where status is NOT 'Not Applied' and NOT 'Draft'
+  const totalApplications = trackedOpps.filter(
+    (i) => i.status !== "Not Applied" && i.status !== "Draft"
+  ).length;
+  const totalSelected = trackedOpps.filter(
+    (i) => i.status === "Selected"
+  ).length;
+
+  const successRate =
+    totalApplications > 0
+      ? Math.round((totalSelected / totalApplications) * 100)
+      : 0;
+  const actionRate =
+    total > 0 ? Math.round((totalApplications / total) * 100) : 0;
+
+  const connectGoogleCalendar = async () => {
+    try {
+      setIsConnectingCalendar(true);
+      await authClient.linkSocial({
+        provider: "google",
+        callbackURL: "/tracker?calendar=connected",
+        scopes: ["https://www.googleapis.com/auth/calendar.events"],
+      });
+    } catch (error) {
+      console.error("Failed to connect Google Calendar", error);
+      toast.error("Could not connect Google Calendar. Please try again.");
+      setIsConnectingCalendar(false);
+    }
+  };
+
+  const addToGoogleCalendar = async (opp: TrackerItem) => {
+    if (!opp.deadline) {
+      toast.error("This item has no deadline to create a calendar event.");
+      return;
     }
 
+    const key = getCalendarKey(opp);
+    setCalendarAddingByKey((prev) => ({ ...prev, [key]: true }));
+
+    try {
+      const response = await fetch("/api/tracker/calendar", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          oppId: String(opp.oppId),
+          title: opp.title || "Untitled Opportunity",
+          company: opp.company || "Unknown Company",
+          deadline: opp.deadline,
+          kind: opp.kind || "internship",
+        }),
+      });
+
+      const data = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        if (data?.code === "GOOGLE_CALENDAR_NOT_CONNECTED") {
+          setIsCalendarConnected(false);
+          toast.error(
+            "Connect Google Calendar first from the tracker header button."
+          );
+          return;
+        }
+        if (data?.code === "GOOGLE_CALENDAR_SCOPE_MISSING") {
+          toast.error(
+            "Calendar permission missing. Reconnect Google Calendar from the tracker header button."
+          );
+          return;
+        }
+        toast.error(data?.error || "Failed to add event to Google Calendar.");
+        return;
+      }
+
+      if (data?.alreadyExists) {
+        setIsCalendarConnected(true);
+        setCalendarAddedByKey((prev) => ({ ...prev, [key]: true }));
+        toast.message("This deadline is already in your Google Calendar.");
+        return;
+      }
+
+      setIsCalendarConnected(true);
+      setCalendarAddedByKey((prev) => ({ ...prev, [key]: true }));
+      toast.success("Added to Google Calendar.");
+    } catch (error) {
+      console.error("Failed to add tracker event to Google Calendar", error);
+      toast.error("Failed to add event to Google Calendar.");
+    } finally {
+      setCalendarAddingByKey((prev) => ({ ...prev, [key]: false }));
+    }
+  };
+
+  if (isLoading) {
     return (
-        <div className="space-y-8 animate-in fade-in duration-500 pb-20 p-4 md:p-8 max-w-7xl mx-auto">
-            {/* Header & Metrics */}
-            <div className="flex flex-col md:flex-row md:items-center justify-between gap-6">
-                <div>
-                    <h2 className="text-3xl font-bold text-slate-900">Personal Tracker</h2>
-                    <p className="text-slate-500">Track, Manage, and Optimize your {activeTab} search.</p>
-                </div>
-
-                <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-4">
-                    {/* Tab Switcher */}
-                    <div className="bg-slate-100 p-1 rounded-lg flex items-center justify-center">
-                        <button
-                            onClick={() => handleTabChange('internship')}
-                            className={cn(
-                                "px-3 py-1.5 rounded-md text-sm font-bold transition-all flex justify-center items-center gap-2",
-                                activeTab === 'internship' ? "bg-white text-slate-900 shadow-sm" : "text-slate-500 hover:text-slate-700"
-                            )}
-                        >
-                            Internships
-                        </button>
-                        <button
-                            onClick={() => handleTabChange('opportunity')}
-                            className={cn(
-                                "px-3 py-1.5 rounded-md text-sm font-bold transition-all flex justify-center items-center gap-2",
-                                activeTab === 'opportunity' ? "bg-white text-slate-900 shadow-sm" : "text-slate-500 hover:text-slate-700"
-                            )}
-                        >
-                            Opportunities
-                        </button>
-                    </div>
-
-                </div>
-            </div>
-
-
-
-            {/* Insights Toggle Bar */}
-            {!showInsights && (
-                <button
-                    onClick={() => setShowInsights(true)}
-                    className="w-full bg-white hover:bg-slate-50 text-slate-900 p-4 rounded-xl shadow-sm border border-slate-200 flex items-center justify-between group transition-all"
-                >
-                    <div className="flex items-center gap-3">
-                        <div className="p-2 bg-slate-100 rounded-lg group-hover:scale-110 transition-transform">
-                            <TrendingUp size={20} className="text-slate-600" />
-                        </div>
-                        <div className="text-left">
-                            <span className="font-bold text-lg">Check Insights</span>
-                            <p className="text-slate-500 text-sm">View your success rate and tracking progress</p>
-                        </div>
-                    </div>
-                    <ChevronRight size={24} className="text-slate-400 group-hover:translate-x-1 transition-transform" />
-                </button>
-            )}
-
-            <AnimatePresence>
-                {showInsights && (
-                    <motion.div
-                        initial={{ height: 0, opacity: 0 }}
-                        animate={{ height: 'auto', opacity: 1 }}
-                        exit={{ height: 0, opacity: 0 }}
-                        transition={{ duration: 0.3, ease: 'easeInOut' }}
-                        className="overflow-hidden space-y-6"
-                    >
-                        <div className="flex items-center justify-between mb-2 px-2">
-                            <h3 className="font-bold text-slate-900 text-lg flex items-center gap-2">
-                                <TrendingUp className="text-orange-500" size={20} />
-                                Tracking Insights
-                            </h3>
-                            <button
-                                onClick={() => setShowInsights(false)}
-                                className="p-2 hover:bg-slate-100 rounded-full text-slate-400 hover:text-slate-600 transition-colors"
-                                title="Close Insights"
-                            >
-                                <X size={20} />
-                            </button>
-                        </div>
-
-                        {/* Mobile Metrics Card (Consolidated) */}
-                        <div className="md:hidden bg-white rounded-2xl p-6 border border-slate-200 shadow-sm relative overflow-hidden">
-                            <div className="flex justify-between items-start mb-6 relative z-10">
-                                <div>
-                                    <h3 className="text-2xl font-bold text-slate-900">{total}</h3>
-                                    <p className="text-slate-500 text-sm">Total Tracked</p>
-                                </div>
-                                <div className="text-right">
-                                    <h3 className="text-2xl font-bold text-emerald-600">{successRate}%</h3>
-                                    <p className="text-slate-500 text-sm">Success Rate</p>
-                                </div>
-                            </div>
-
-                            <div className="flex items-center gap-4 bg-blue-50 p-3 rounded-xl relative z-10 border border-blue-200">
-                                <div className="p-2 bg-blue-100 text-blue-700 rounded-lg">
-                                    <Activity size={20} />
-                                </div>
-                                <div>
-                                    <h4 className="font-bold text-lg text-slate-900">{actionRate}%</h4>
-                                    <p className="text-xs text-slate-500">Action Rate</p>
-                                </div>
-                            </div>
-                        </div>
-
-                        {/* Desktop Metrics Grid */}
-                        <div className="hidden md:grid grid-cols-1 md:grid-cols-3 gap-6">
-                            <MetricCard icon={FileText} label="Total Tracked" value={total} color="bg-slate-100 text-slate-700" />
-                            <MetricCard icon={TrendingUp} label="Success Rate" value={`${successRate}%`} color="bg-emerald-50 text-emerald-700" />
-                            <MetricCard icon={Activity} label="Action Rate" value={`${actionRate}%`} color="bg-blue-50 text-blue-700" />
-                        </div>
-                    </motion.div>
-                )}
-            </AnimatePresence>
-
-            {/* View Content */}
-            <div className="space-y-8">
-
-                {/* Main List */}
-                <div className="bg-white rounded-2xl border border-slate-200 shadow-sm">
-                    <div className="p-4 md:p-5 border-b border-slate-100 flex justify-between items-center sticky top-0 z-20 bg-white/95 backdrop-blur-md rounded-t-2xl">
-                        <h3 className="font-bold text-slate-900 text-sm md:text-lg shrink-0">Saved {activeTab === 'internship' ? 'Internships' : 'Opportunities'}</h3>
-                        <Link
-                            href="/toolkit"
-                            className="flex items-center gap-1.5 px-3 py-1.5 bg-orange-600 hover:bg-orange-700 text-white rounded-xl text-[10px] md:text-sm font-bold transition-all shadow-sm hover:shadow-orange-200"
-                        >
-                            <Zap size={14} className="fill-white" />
-                            <span>10x Chances</span>
-                        </Link>
-                    </div>
-                    <div className="divide-y divide-slate-100">
-                        {trackedOpps
-                            .sort((a, b) => {
-                                const dateA = a.deadline ? new Date(a.deadline).getTime() : 9999999999999;
-                                const dateB = b.deadline ? new Date(b.deadline).getTime() : 9999999999999;
-                                return dateA - dateB;
-                            })
-                            .map(opp => (
-                                <div key={opp.oppId}>
-                                    <div className="md:hidden">
-                                        <MobileTrackerCard
-                                            opp={opp}
-                                            updateStatus={updateStatus}
-                                            onDelete={removeFromTracker}
-                                            onClick={(o) => {
-                                                const path = (o.kind || 'internship') === 'internship'
-                                                    ? `/intern/${o.oppId}`
-                                                    : `/opportunities/${o.oppId}`;
-                                                router.push(path);
-                                            }}
-                                        />
-                                    </div>
-                                    <div className="hidden md:block">
-                                        <TrackerRow
-                                            opp={opp}
-                                            updateStatus={updateStatus}
-                                            onDelete={removeFromTracker}
-                                            onClick={(o) => {
-                                                const path = (o.kind || 'internship') === 'internship'
-                                                    ? `/intern/${o.oppId}`
-                                                    : `/opportunities/${o.oppId}`;
-                                                router.push(path);
-                                            }}
-                                        />
-                                    </div>
-                                </div>
-                            ))}
-                        {trackedOpps.length === 0 && (
-                            <div className="p-8 text-center text-slate-500">
-                                No applications tracked yet. Start by adding one!
-                            </div>
-                        )}
-                    </div>
-                </div>
-            </div>
-
-
-
-            <TrackerDetailModal
-                isOpen={!!detailOpp}
-                onClose={() => setDetailOpp(null)}
-                opportunity={detailOpp}
-                updateStatus={updateStatus}
-                onSmartApply={() => {
-                    setSmartApplyOpp(detailOpp);
-                    setDetailOpp(null);
-                }}
-            />
-
-
-
-            <ApplyModal
-                isOpen={!!smartApplyOpp}
-                onClose={() => setSmartApplyOpp(null)}
-                opportunity={smartApplyOpp ? {
-                    ...smartApplyOpp,
-                    id: smartApplyOpp.oppId,
-                    title: smartApplyOpp.title || "Untitled Opportunity"
-                } as unknown as ApplyModalOpportunity : null}
-            />
-        </div>
+      <div className="flex h-[50vh] w-full items-center justify-center">
+        <Loader2 className="animate-spin text-slate-400" size={32} />
+      </div>
     );
+  }
+
+  return (
+    <div className="animate-in fade-in mx-auto max-w-7xl space-y-8 p-4 pb-20 duration-500 md:p-8">
+      {/* Header & Metrics */}
+      <div className="flex flex-col justify-between gap-6 md:flex-row md:items-center">
+        <div>
+          <h2 className="text-3xl font-bold text-slate-900">
+            Personal Tracker
+          </h2>
+          <p className="text-slate-500">
+            Track, Manage, and Optimize your {activeTab} search.
+          </p>
+        </div>
+
+        <div className="flex flex-col items-stretch gap-4 sm:flex-row sm:items-center">
+          {/* Tab Switcher */}
+          <div className="flex items-center justify-center rounded-lg bg-slate-100 p-1">
+            <button
+              onClick={() => handleTabChange("internship")}
+              className={cn(
+                "flex items-center justify-center gap-2 rounded-md px-3 py-1.5 text-sm font-bold transition-all",
+                activeTab === "internship"
+                  ? "bg-white text-slate-900 shadow-sm"
+                  : "text-slate-500 hover:text-slate-700"
+              )}
+            >
+              Internships
+            </button>
+            <button
+              onClick={() => handleTabChange("opportunity")}
+              className={cn(
+                "flex items-center justify-center gap-2 rounded-md px-3 py-1.5 text-sm font-bold transition-all",
+                activeTab === "opportunity"
+                  ? "bg-white text-slate-900 shadow-sm"
+                  : "text-slate-500 hover:text-slate-700"
+              )}
+            >
+              Opportunities
+            </button>
+          </div>
+
+          {isCalendarConfigLoading ? (
+            <button
+              type="button"
+              disabled
+              className="rounded-md border border-slate-200/80 bg-slate-50 px-3 py-1.5 text-sm font-semibold text-slate-500"
+            >
+              Loading Calendar...
+            </button>
+          ) : isCalendarConnected ? (
+            <Popover>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-1.5 rounded-md border border-slate-200/80 bg-slate-50 px-3 py-1.5 text-sm font-semibold text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-700"
+                >
+                  <CalendarCog size={14} /> Calendar Config
+                </button>
+              </PopoverTrigger>
+              <PopoverContent align="end" className="w-80 space-y-3">
+                <div>
+                  <h4 className="text-sm font-semibold text-slate-900">
+                    Reminder Notifications
+                  </h4>
+                  <p className="text-xs text-slate-500">
+                    Controls for new tracker events added to Google Calendar.
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between rounded-lg border p-3">
+                    <div>
+                      <p className="text-sm font-medium text-slate-900">
+                        1 Week Before
+                      </p>
+                      <p className="text-xs text-slate-500">
+                        10080 minutes before deadline
+                      </p>
+                    </div>
+                    <Switch
+                      checked={calendarReminderSettings.weekBefore}
+                      onCheckedChange={(checked) =>
+                        updateCalendarReminderSetting("weekBefore", checked)
+                      }
+                      disabled={isSavingCalendarSettings}
+                    />
+                  </div>
+
+                  <div className="flex items-center justify-between rounded-lg border p-3">
+                    <div>
+                      <p className="text-sm font-medium text-slate-900">
+                        1 Day Before
+                      </p>
+                      <p className="text-xs text-slate-500">
+                        1440 minutes before deadline
+                      </p>
+                    </div>
+                    <Switch
+                      checked={calendarReminderSettings.dayBefore}
+                      onCheckedChange={(checked) =>
+                        updateCalendarReminderSetting("dayBefore", checked)
+                      }
+                      disabled={isSavingCalendarSettings}
+                    />
+                  </div>
+
+                  <div className="flex items-center justify-between rounded-lg border p-3">
+                    <div>
+                      <p className="text-sm font-medium text-slate-900">
+                        1 Hour Before
+                      </p>
+                      <p className="text-xs text-slate-500">
+                        60 minutes before deadline
+                      </p>
+                    </div>
+                    <Switch
+                      checked={calendarReminderSettings.hourBefore}
+                      onCheckedChange={(checked) =>
+                        updateCalendarReminderSetting("hourBefore", checked)
+                      }
+                      disabled={isSavingCalendarSettings}
+                    />
+                  </div>
+                </div>
+              </PopoverContent>
+            </Popover>
+          ) : (
+            <button
+              type="button"
+              onClick={connectGoogleCalendar}
+              disabled={isConnectingCalendar}
+              className="rounded-md border border-slate-200/80 bg-slate-50 px-3 py-1.5 text-sm font-semibold text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-700 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isConnectingCalendar
+                ? "Connecting..."
+                : "Connect Google Calendar"}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Insights Toggle Bar */}
+      {!showInsights && (
+        <button
+          onClick={() => setShowInsights(true)}
+          className="group flex w-full items-center justify-between rounded-xl border border-slate-200 bg-white p-4 text-slate-900 shadow-sm transition-all hover:bg-slate-50"
+        >
+          <div className="flex items-center gap-3">
+            <div className="rounded-lg bg-slate-100 p-2 transition-transform group-hover:scale-110">
+              <TrendingUp size={20} className="text-slate-600" />
+            </div>
+            <div className="text-left">
+              <span className="text-lg font-bold">Check Insights</span>
+              <p className="text-sm text-slate-500">
+                View your success rate and tracking progress
+              </p>
+            </div>
+          </div>
+          <ChevronRight
+            size={24}
+            className="text-slate-400 transition-transform group-hover:translate-x-1"
+          />
+        </button>
+      )}
+
+      <AnimatePresence>
+        {showInsights && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.3, ease: "easeInOut" }}
+            className="space-y-6 overflow-hidden"
+          >
+            <div className="mb-2 flex items-center justify-between px-2">
+              <h3 className="flex items-center gap-2 text-lg font-bold text-slate-900">
+                <TrendingUp className="text-orange-500" size={20} />
+                Tracking Insights
+              </h3>
+              <button
+                onClick={() => setShowInsights(false)}
+                className="rounded-full p-2 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600"
+                title="Close Insights"
+              >
+                <X size={20} />
+              </button>
+            </div>
+
+            {/* Mobile Metrics Card (Consolidated) */}
+            <div className="relative overflow-hidden rounded-2xl border border-slate-200 bg-white p-6 shadow-sm md:hidden">
+              <div className="relative z-10 mb-6 flex items-start justify-between">
+                <div>
+                  <h3 className="text-2xl font-bold text-slate-900">{total}</h3>
+                  <p className="text-sm text-slate-500">Total Tracked</p>
+                </div>
+                <div className="text-right">
+                  <h3 className="text-2xl font-bold text-emerald-600">
+                    {successRate}%
+                  </h3>
+                  <p className="text-sm text-slate-500">Success Rate</p>
+                </div>
+              </div>
+
+              <div className="relative z-10 flex items-center gap-4 rounded-xl border border-blue-200 bg-blue-50 p-3">
+                <div className="rounded-lg bg-blue-100 p-2 text-blue-700">
+                  <Activity size={20} />
+                </div>
+                <div>
+                  <h4 className="text-lg font-bold text-slate-900">
+                    {actionRate}%
+                  </h4>
+                  <p className="text-xs text-slate-500">Action Rate</p>
+                </div>
+              </div>
+            </div>
+
+            {/* Desktop Metrics Grid */}
+            <div className="hidden grid-cols-1 gap-6 md:grid md:grid-cols-3">
+              <MetricCard
+                icon={FileText}
+                label="Total Tracked"
+                value={total}
+                color="bg-slate-100 text-slate-700"
+              />
+              <MetricCard
+                icon={TrendingUp}
+                label="Success Rate"
+                value={`${successRate}%`}
+                color="bg-emerald-50 text-emerald-700"
+              />
+              <MetricCard
+                icon={Activity}
+                label="Action Rate"
+                value={`${actionRate}%`}
+                color="bg-blue-50 text-blue-700"
+              />
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* View Content */}
+      <div className="space-y-8">
+        {/* Main List */}
+        <div className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <div className="sticky top-0 z-20 flex items-center justify-between rounded-t-2xl border-b border-slate-100 bg-white/95 p-4 backdrop-blur-md md:p-5">
+            <h3 className="shrink-0 text-sm font-bold text-slate-900 md:text-lg">
+              Saved{" "}
+              {activeTab === "internship" ? "Internships" : "Opportunities"}
+            </h3>
+            <Link
+              href="/toolkit"
+              className="flex items-center gap-1.5 rounded-xl bg-orange-600 px-3 py-1.5 text-[10px] font-bold text-white shadow-sm transition-all hover:bg-orange-700 hover:shadow-orange-200 md:text-sm"
+            >
+              <Zap size={14} className="fill-white" />
+              <span>10x Chances</span>
+            </Link>
+          </div>
+          <div className="divide-y divide-slate-100">
+            {trackedOpps
+              .sort((a, b) => {
+                const dateA = a.deadline
+                  ? new Date(a.deadline).getTime()
+                  : 9999999999999;
+                const dateB = b.deadline
+                  ? new Date(b.deadline).getTime()
+                  : 9999999999999;
+                return dateA - dateB;
+              })
+              .map((opp) => (
+                <div key={opp.oppId}>
+                  <div className="md:hidden">
+                    <MobileTrackerCard
+                      opp={opp}
+                      updateStatus={updateStatus}
+                      onDelete={removeFromTracker}
+                      onAddToCalendar={addToGoogleCalendar}
+                      isCalendarAdded={
+                        !!opp.calendarEventId ||
+                        !!calendarAddedByKey[getCalendarKey(opp)]
+                      }
+                      isCalendarAdding={
+                        !!calendarAddingByKey[getCalendarKey(opp)]
+                      }
+                      onClick={(o) => {
+                        const path =
+                          (o.kind || "internship") === "internship"
+                            ? `/intern/${o.oppId}`
+                            : `/opportunities/${o.oppId}`;
+                        router.push(path);
+                      }}
+                    />
+                  </div>
+                  <div className="hidden md:block">
+                    <TrackerRow
+                      opp={opp}
+                      updateStatus={updateStatus}
+                      onDelete={removeFromTracker}
+                      onAddToCalendar={addToGoogleCalendar}
+                      isCalendarAdded={
+                        !!opp.calendarEventId ||
+                        !!calendarAddedByKey[getCalendarKey(opp)]
+                      }
+                      isCalendarAdding={
+                        !!calendarAddingByKey[getCalendarKey(opp)]
+                      }
+                      onClick={(o) => {
+                        const path =
+                          (o.kind || "internship") === "internship"
+                            ? `/intern/${o.oppId}`
+                            : `/opportunities/${o.oppId}`;
+                        router.push(path);
+                      }}
+                    />
+                  </div>
+                </div>
+              ))}
+            {trackedOpps.length === 0 && (
+              <div className="p-8 text-center text-slate-500">
+                No applications tracked yet. Start by adding one!
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <TrackerDetailModal
+        isOpen={!!detailOpp}
+        onClose={() => setDetailOpp(null)}
+        opportunity={detailOpp}
+        updateStatus={updateStatus}
+        onSmartApply={() => {
+          setSmartApplyOpp(detailOpp);
+          setDetailOpp(null);
+        }}
+      />
+
+      <ApplyModal
+        isOpen={!!smartApplyOpp}
+        onClose={() => setSmartApplyOpp(null)}
+        opportunity={
+          smartApplyOpp
+            ? ({
+                ...smartApplyOpp,
+                id: smartApplyOpp.oppId,
+                title: smartApplyOpp.title || "Untitled Opportunity",
+              } as unknown as ApplyModalOpportunity)
+            : null
+        }
+      />
+    </div>
+  );
 }
 
-function MetricCard({ icon: Icon, label, value, color, highlight }: MetricCardProps) {
-    return (
-        <div className={cn(
-            "p-5 rounded-2xl border transition-all",
-            highlight ? "bg-white border-amber-300 shadow-md ring-2 ring-amber-100" : "bg-white border-slate-200"
-        )}>
-            <div className="flex items-center gap-3 mb-2">
-                <div className={cn("p-2 rounded-lg", color)}>
-                    <Icon size={18} />
-                </div>
-                <span className="text-sm font-medium text-slate-500">{label}</span>
-            </div>
-            <p className="text-3xl font-bold text-slate-900 ml-1">{value}</p>
+function MetricCard({
+  icon: Icon,
+  label,
+  value,
+  color,
+  highlight,
+}: MetricCardProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border p-5 transition-all",
+        highlight
+          ? "border-amber-300 bg-white shadow-md ring-2 ring-amber-100"
+          : "border-slate-200 bg-white"
+      )}
+    >
+      <div className="mb-2 flex items-center gap-3">
+        <div className={cn("rounded-lg p-2", color)}>
+          <Icon size={18} />
         </div>
-    );
+        <span className="text-sm font-medium text-slate-500">{label}</span>
+      </div>
+      <p className="ml-1 text-3xl font-bold text-slate-900">{value}</p>
+    </div>
+  );
 }

--- a/components/tracker/TrackerRow.tsx
+++ b/components/tracker/TrackerRow.tsx
@@ -1,117 +1,208 @@
-import { Clock, AlertCircle, Trash2, ChevronDown, Calendar } from 'lucide-react';
-import clsx from 'clsx';
-import { TrackerItem } from '@/components/providers/TrackerProvider';
-import { differenceInCalendarDays } from 'date-fns';
+import {
+  AlertCircle,
+  Calendar,
+  CalendarCheck,
+  CalendarPlus2,
+  ChevronDown,
+  Clock,
+  Trash2,
+} from "lucide-react";
+import clsx from "clsx";
+import { TrackerItem } from "@/components/providers/TrackerProvider";
+import { differenceInCalendarDays, format } from "date-fns";
+
+function formatDateDDMMYYYY(dateText: string) {
+  const parsedDate = new Date(dateText);
+  if (Number.isNaN(parsedDate.getTime())) {
+    return dateText;
+  }
+
+  return format(parsedDate, "dd/MM/yyyy");
+}
 
 function DeadlineBadge({ deadline }: { deadline: string }) {
-    const daysDiff = differenceInCalendarDays(new Date(deadline), new Date());
-    if (daysDiff < 0) {
-        return <span className="text-[10px] font-bold bg-red-50 text-red-600 border border-red-200 px-2 py-0.5 rounded-full">Closed</span>;
-    }
-    if (daysDiff === 0) {
-        return <span className="text-[10px] font-bold bg-orange-50 text-orange-600 border border-orange-200 px-2 py-0.5 rounded-full animate-pulse">Deadline today!</span>;
-    }
-    if (daysDiff <= 3) {
-        return <span className="text-[10px] font-bold bg-rose-50 text-rose-600 border border-rose-200 px-2 py-0.5 rounded-full">{daysDiff}d left</span>;
-    }
-    if (daysDiff <= 7) {
-        return <span className="text-[10px] font-bold bg-amber-50 text-amber-600 border border-amber-200 px-2 py-0.5 rounded-full">{daysDiff} days left</span>;
-    }
-    return <span className="text-[10px] font-bold bg-green-50 text-green-600 border border-green-200 px-2 py-0.5 rounded-full">{daysDiff} days left</span>;
+  const daysDiff = differenceInCalendarDays(new Date(deadline), new Date());
+  if (daysDiff < 0) {
+    return (
+      <span className="rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[10px] font-bold text-red-600">
+        Closed
+      </span>
+    );
+  }
+  if (daysDiff === 0) {
+    return (
+      <span className="animate-pulse rounded-full border border-orange-200 bg-orange-50 px-2 py-0.5 text-[10px] font-bold text-orange-600">
+        Deadline today!
+      </span>
+    );
+  }
+  if (daysDiff <= 3) {
+    return (
+      <span className="rounded-full border border-rose-200 bg-rose-50 px-2 py-0.5 text-[10px] font-bold text-rose-600">
+        {daysDiff}d left
+      </span>
+    );
+  }
+  if (daysDiff <= 7) {
+    return (
+      <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[10px] font-bold text-amber-600">
+        {daysDiff} days left
+      </span>
+    );
+  }
+  return (
+    <span className="rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-[10px] font-bold text-green-600">
+      {daysDiff} days left
+    </span>
+  );
 }
 
 interface TrackerRowProps {
-    opp: TrackerItem & { isHighPriority?: boolean };
-    updateStatus: (id: number | string, status: string, extraData?: Record<string, unknown>) => void;
-    onClick: (opp: TrackerItem) => void;
-    onDelete: (id: number | string) => void;
-
+  opp: TrackerItem & { isHighPriority?: boolean };
+  updateStatus: (
+    id: number | string,
+    status: string,
+    extraData?: Record<string, unknown>
+  ) => void;
+  onClick: (opp: TrackerItem) => void;
+  onDelete: (id: number | string) => void;
+  onAddToCalendar: (opp: TrackerItem) => void;
+  isCalendarAdded: boolean;
+  isCalendarAdding: boolean;
 }
 
-export default function TrackerRow({ opp, updateStatus, onClick, onDelete }: TrackerRowProps) {
-    return (
-        <div
-            onClick={() => onClick(opp)}
-            className="p-5 hover:bg-slate-50 transition-colors flex flex-col md:flex-row md:items-center gap-4 group cursor-pointer"
-        >
-            <div className="flex items-center gap-4 flex-1 min-w-0">
-                {(opp.logo || opp.poster || opp.images?.[0]) ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img src={opp.logo || opp.poster || opp.images?.[0]} alt={opp.company} className="w-12 h-12 rounded-xl object-contain bg-white border border-slate-100 p-1" />
-                ) : (
-                    <div className="w-12 h-12 bg-slate-100 rounded-xl flex items-center justify-center text-slate-500 font-bold text-lg">
-                        {opp.company ? opp.company.charAt(0) : '?'}
-                    </div>
+export default function TrackerRow({
+  opp,
+  updateStatus,
+  onClick,
+  onDelete,
+  onAddToCalendar,
+  isCalendarAdded,
+  isCalendarAdding,
+}: TrackerRowProps) {
+  return (
+    <div
+      onClick={() => onClick(opp)}
+      className="group flex cursor-pointer flex-col gap-4 p-5 transition-colors hover:bg-slate-50 md:flex-row md:items-center"
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-4">
+        {opp.logo || opp.poster || opp.images?.[0] ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={opp.logo || opp.poster || opp.images?.[0]}
+            alt={opp.company}
+            className="h-12 w-12 rounded-xl border border-slate-100 bg-white object-contain p-1"
+          />
+        ) : (
+          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-slate-100 text-lg font-bold text-slate-500">
+            {opp.company ? opp.company.charAt(0) : "?"}
+          </div>
+        )}
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h4 className="truncate font-bold text-slate-900">{opp.title}</h4>
+            <span
+              className={clsx(
+                "rounded-md px-2 py-0.5 text-[10px] font-bold tracking-wide uppercase",
+                opp.fitColor
+              )}
+            >
+              {opp.fitLabel}
+            </span>
+          </div>
+          <div className="mt-0.5 flex items-center gap-3 text-sm text-slate-500">
+            <span>{opp.company}</span>
+            {opp.deadline && (
+              <span
+                className={clsx(
+                  "flex items-center gap-1",
+                  opp.isHighPriority ? "font-bold text-rose-600" : ""
                 )}
-                <div className="min-w-0">
-                    <div className="flex items-center gap-2">
-                        <h4 className="font-bold text-slate-900 truncate">{opp.title}</h4>
-                        <span className={clsx("px-2 py-0.5 rounded-md text-[10px] font-bold uppercase tracking-wide", opp.fitColor)}>
-                            {opp.fitLabel}
-                        </span>
-                    </div>
-                    <div className="flex items-center gap-3 text-sm text-slate-500 mt-0.5">
-                        <span>{opp.company}</span>
-                        {opp.deadline && (
-                            <span className={clsx("flex items-center gap-1",
-                                opp.isHighPriority ? "text-rose-600 font-bold" : ""
-                            )}>
-                                <Clock size={12} /> {new Date(opp.deadline).toLocaleDateString()}
-                            </span>
-                        )}
-                        {opp.deadline && opp.kind === 'opportunity' && (
-                            <DeadlineBadge deadline={opp.deadline} />
-                        )}
-                        {opp.expectedResultWindow && (
-                            <span className="flex items-center gap-1 text-xs text-slate-400">
-                                <Calendar size={12} /> Exp: {opp.expectedResultWindow}
-                            </span>
-                        )}
-                        {opp.isHighPriority && (
-                            <span className="flex items-center gap-1 text-xs font-bold text-rose-600 bg-rose-50 px-2 py-0.5 rounded-full border border-rose-100">
-                                <AlertCircle size={10} /> HIGH PRIORITY
-                            </span>
-                        )}
-                    </div>
-                </div>
-            </div>
-
-            <div className="w-full md:w-auto mt-2 md:mt-0 flex items-center gap-2">
-                <div className="relative" onClick={(e) => e.stopPropagation()}>
-                    <select
-                        value={opp.status}
-                        onChange={(e) => updateStatus(opp.oppId, e.target.value)}
-                        className="appearance-none bg-white border border-slate-200 rounded-lg text-sm font-medium text-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-200 cursor-pointer pl-3 pr-8 py-2"
-                    >
-                        {['Not Applied', 'Applied', 'Result Awaited', 'Selected', 'Rejected'].map(s => <option key={s} value={s}>{s}</option>)}
-                    </select>
-                    <ChevronDown size={14} className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none" />
-                </div>
-            </div>
-
-            <div className="flex items-center gap-1">
-                {opp.deadline && (
-                    <a
-                        href={`https://www.google.com/calendar/render?action=TEMPLATE&text=Deadline: ${encodeURIComponent(opp.title)}&dates=${new Date(opp.deadline).toISOString().replace(/-|:|\.\d\d\d/g, "")}/${new Date(opp.deadline).toISOString().replace(/-|:|\.\d\d\d/g, "")}&details=Company: ${encodeURIComponent(opp.company)}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        onClick={(e) => e.stopPropagation()}
-                        className="p-2 text-slate-400 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
-                        title="Add to Google Calendar"
-                    >
-                        {/* eslint-disable-next-line @next/next/no-img-element */}
-                        <img src="/images/google-calendar.webp" alt="Google Calendar" className="w-5 h-5 object-contain" />
-                    </a>
-                )}
-                <button
-                    onClick={(e) => { e.stopPropagation(); onDelete(opp.oppId); }}
-                    className="p-2 text-rose-500 hover:text-rose-600 hover:bg-rose-50 rounded-lg transition-colors"
-                    title="Remove from Tracker"
-                >
-                    <Trash2 size={16} />
-                </button>
-            </div>
+              >
+                <Clock size={12} /> {formatDateDDMMYYYY(opp.deadline)}
+              </span>
+            )}
+            {opp.deadline && opp.kind === "opportunity" && (
+              <DeadlineBadge deadline={opp.deadline} />
+            )}
+            {opp.expectedResultWindow && (
+              <span className="flex items-center gap-1 text-xs text-slate-400">
+                <Calendar size={12} /> Exp: {opp.expectedResultWindow}
+              </span>
+            )}
+            {opp.isHighPriority && (
+              <span className="flex items-center gap-1 rounded-full border border-rose-100 bg-rose-50 px-2 py-0.5 text-xs font-bold text-rose-600">
+                <AlertCircle size={10} /> HIGH PRIORITY
+              </span>
+            )}
+          </div>
         </div>
+      </div>
 
-    );
+      <div className="mt-2 flex w-full items-center gap-2 md:mt-0 md:w-auto">
+        <div className="relative" onClick={(e) => e.stopPropagation()}>
+          <select
+            value={opp.status}
+            onChange={(e) => updateStatus(opp.oppId, e.target.value)}
+            className="cursor-pointer appearance-none rounded-lg border border-slate-200 bg-white py-2 pr-8 pl-3 text-sm font-medium text-slate-700 focus:ring-2 focus:ring-slate-200 focus:outline-none"
+          >
+            {[
+              "Not Applied",
+              "Applied",
+              "Result Awaited",
+              "Selected",
+              "Rejected",
+            ].map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+          <ChevronDown
+            size={14}
+            className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 text-slate-400"
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center gap-1">
+        {opp.deadline && (
+          <button
+            type="button"
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              onAddToCalendar(opp);
+            }}
+            disabled={isCalendarAdding}
+            className="rounded-lg p-2 text-slate-400 transition-colors hover:bg-blue-50 hover:text-blue-600"
+            title={
+              isCalendarAdded
+                ? "Added to Google Calendar"
+                : "Add to Google Calendar"
+            }
+          >
+            {isCalendarAdded ? (
+              <CalendarCheck size={18} className="text-emerald-600" />
+            ) : (
+              <CalendarPlus2
+                size={18}
+                className={isCalendarAdding ? "animate-pulse" : ""}
+              />
+            )}
+          </button>
+        )}
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete(opp.oppId);
+          }}
+          className="rounded-lg p-2 text-rose-500 transition-colors hover:bg-rose-50 hover:text-rose-600"
+          title="Remove from Tracker"
+        >
+          <Trash2 size={16} />
+        </button>
+      </div>
+    </div>
+  );
 }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -51,6 +51,8 @@ export const auth = betterAuth({
     google: {
       clientId: process.env.GOOGLE_CLIENT_ID!,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      accessType: "offline",
+      prompt: "select_account consent",
     },
     linkedin: {
       clientId: process.env.LINKEDIN_CLIENT_ID!,

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -109,6 +109,9 @@ export const user = pgTable("user", {
     .$defaultFn(() => false)
     .notNull(),
   image: text("image"),
+  calendarReminderWeek: boolean("calendar_reminder_week").default(true),
+  calendarReminderDay: boolean("calendar_reminder_day").default(true),
+  calendarReminderHour: boolean("calendar_reminder_hour").default(true),
   fieldInterests: text("field_interests").array().default([]),
   opportunityInterests: text("opportunity_interests").array().default([]),
   dateOfBirth: date("date_of_birth"),
@@ -423,26 +426,36 @@ export const trackerItems = pgTable(
     result: text("result"),
     isManual: boolean("is_manual").default(false),
     manualData: text("manual_data"), // storing JSON stringified manual data
+    calendarEventId: text("calendar_event_id"),
+    calendarEventSyncedAt: timestamp("calendar_event_synced_at"),
   },
   (table) => [
     uniqueIndex("tracker_items_user_opp_unique").on(table.userId, table.oppId),
   ]
 );
 
-export const trackerEvents = pgTable("tracker_events", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  userId: text("user_id")
-    .notNull()
-    .references(() => user.id, { onDelete: "cascade" }),
-  title: text("title").notNull(),
-  date: timestamp("date").notNull(),
-  type: text("type").notNull(),
-  description: text("description"),
-  createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at").defaultNow(),
-}, (table) => [
-  uniqueIndex("tracker_events_user_title_date_unique").on(table.userId, table.title, table.date),
-]);
+export const trackerEvents = pgTable(
+  "tracker_events",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    title: text("title").notNull(),
+    date: timestamp("date").notNull(),
+    type: text("type").notNull(),
+    description: text("description"),
+    createdAt: timestamp("created_at").defaultNow(),
+    updatedAt: timestamp("updated_at").defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("tracker_events_user_title_date_unique").on(
+      table.userId,
+      table.title,
+      table.date
+    ),
+  ]
+);
 
 // Export schema object last
 export const schema = {

--- a/migrations/0029_add_tracker_calendar_event_columns.sql
+++ b/migrations/0029_add_tracker_calendar_event_columns.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "tracker_items"
+ADD COLUMN "calendar_event_id" text,
+ADD COLUMN "calendar_event_synced_at" timestamp;

--- a/migrations/0030_add_calendar_notification_preferences.sql
+++ b/migrations/0030_add_calendar_notification_preferences.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "user"
+ADD COLUMN "calendar_reminder_week" boolean DEFAULT true,
+ADD COLUMN "calendar_reminder_day" boolean DEFAULT true,
+ADD COLUMN "calendar_reminder_hour" boolean DEFAULT true;


### PR DESCRIPTION
## Summary
- Replace tracker's URL-based calendar action with direct Google Calendar event creation via a new `/api/tracker/calendar` endpoint.
- Add tracker-level Google Calendar connect/config UX with scope-aware connection checks and reminder toggle preferences (1 week, 1 day, 1 hour).
- Persist calendar sync state and reminder preferences in DB, and keep calendar icon state consistent (plus -> check) across refresh.

## Validation
- npm run lint
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Google Calendar integration: Connect your account and add tracker items as calendar events with automatic duplicate detection
  * Reminder preferences: Customize notification timing with toggles for reminders 1 week, 1 day, or 1 hour before deadlines
  * Enhanced tracker interface: New calendar controls and deadline status indicators across all tracker views

<!-- end of auto-generated comment: release notes by coderabbit.ai -->