### PR TITLE
changed to Internship Guide Button

### DIFF
--- a/components/tracker/Tracker.tsx
+++ b/components/tracker/Tracker.tsx
@@ -254,7 +254,7 @@ export default function Tracker() {
                                 className="flex items-center gap-1.5 px-3 py-1.5 bg-orange-600 hover:bg-orange-700 text-white rounded-xl text-[10px] md:text-sm font-bold transition-all shadow-sm hover:shadow-orange-200"
                             >
                                 <Zap size={14} className="fill-white" />
-                                <span>10x Chances</span>
+                                <span>Internship Guide</span>
                             </Link>
                         )}
                     </div>


### PR DESCRIPTION
In tracker page,the text of 10x chances button is changed to Internship Guide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated link label in the Internship tracker section for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->